### PR TITLE
Fix(stations): Manually geocode stations and improve fixing scripts

### DIFF
--- a/listInvalidStations.js
+++ b/listInvalidStations.js
@@ -1,0 +1,51 @@
+import fs from 'fs/promises';
+
+const TV_STATIONS_PATH = './src/data/tvStationsWithUrlsFixed.json';
+const RADIO_STATIONS_PATH = './src/data/radioStationsFixed.json';
+
+async function listAtlanticGridStations(filePath, dataType) {
+  try {
+    const stationsData = await fs.readFile(filePath, 'utf8');
+    const stations = JSON.parse(stationsData);
+
+    const gridStations = stations.filter(station => {
+      const lat = parseFloat(station.geo_lat);
+      const lon = parseFloat(station.geo_long);
+
+      // Bounding box for the Atlantic grid pattern
+      const is_in_grid = (
+        lat > 20 && lat < 70 &&
+        lon > -100 && lon < -20
+      );
+
+      return is_in_grid;
+    });
+
+    if (gridStations.length > 0) {
+      console.log(`\n--- ${dataType} Stations in Atlantic Grid ---`);
+      gridStations.forEach(station => {
+        console.log(`ID: ${station.id}, Name: ${station.name}, Lat: ${station.geo_lat}, Lon: ${station.geo_long}`);
+      });
+    }
+    return gridStations;
+
+  } catch (error) {
+    console.error(`Error processing ${filePath}:`, error);
+    return [];
+  }
+}
+
+async function main() {
+  console.log('--- Identifying remaining stations in the Atlantic grid ---');
+  const tvStations = await listAtlanticGridStations(TV_STATIONS_PATH, 'TV');
+  const radioStations = await listAtlanticGridStations(RADIO_STATIONS_PATH, 'Radio');
+
+  const total = tvStations.length + radioStations.length;
+  if (total === 0) {
+    console.log('\n✅ No stations found in the Atlantic grid.');
+  } else {
+    console.log(`\n❌ Found a total of ${total} stations in the Atlantic grid.`);
+  }
+}
+
+main();

--- a/src/data/tvStationsWithUrlsFixed.json
+++ b/src/data/tvStationsWithUrlsFixed.json
@@ -47,13 +47,13 @@
     "url": "https://tv.cdn.xsg.ge/gpb-1tv/index.m3u8",
     "logo": "https://i.imgur.com/FSkYLPK.png",
     "country": "Georgia",
-    "city": "Unknown",
+    "city": "Tbilisi",
     "categories": "General",
     "type": "tv",
-    "geo_lat": 32.3293809,
-    "geo_long": -83.1137366,
-    "latitude": 32.3293809,
-    "longitude": -83.1137366
+    "geo_lat": 41.7151,
+    "geo_long": 44.8271,
+    "latitude": 41.7151,
+    "longitude": 44.8271
   },
   {
     "id": "1TwenteTV.nl@SD",
@@ -117,13 +117,13 @@
     "url": "https://tv.cdn.xsg.ge/gpb-2tv/index.m3u8",
     "logo": "https://i.imgur.com/FJBL6zI.png",
     "country": "Georgia",
-    "city": "Unknown",
+    "city": "Tbilisi",
     "categories": "General",
     "type": "tv",
-    "geo_lat": 32.3293809,
-    "geo_long": -83.1137366,
-    "latitude": 32.3293809,
-    "longitude": -83.1137366
+    "geo_lat": 41.7151,
+    "geo_long": 44.8271,
+    "latitude": 41.7151,
+    "longitude": 44.8271
   },
   {
     "id": "3HD.th",
@@ -592,14 +592,14 @@
     "name": "ABC 3 Lafayette LA (KATC) (720p)",
     "url": "https://aegis-cloudfront-1.tubi.video/28467730-4b65-4c85-8151-4c7d162c0896/playlist.m3u8",
     "logo": "https://upload.wikimedia.org/wikipedia/commons/2/27/WWAY_logo.png",
-    "country": "Unknown",
-    "city": "ABC 3 Lafayette LA KATC 720p",
+    "country": "United States",
+    "city": "Lafayette",
     "categories": "General",
     "type": "tv",
-    "geo_lat": 30.2262187,
-    "geo_long": -92.0178202,
-    "latitude": 30.2241,
-    "longitude": -92.0198
+    "geo_lat": 30.20806,
+    "geo_long": -92.03250,
+    "latitude": 30.20806,
+    "longitude": -92.03250
   },
   {
     "id": "KRGVDT1.us",
@@ -1166,14 +1166,14 @@
     "name": "Ajyal TV (720p)",
     "url": "http://htvmada.mada.ps:8888/ajyal/index.m3u8",
     "logo": "https://i.imgur.com/i6Y7beR.jpg",
-    "country": "Unknown",
-    "city": "Ajyal",
+    "country": "Palestine",
+    "city": "Gaza",
     "categories": "General",
     "type": "tv",
-    "geo_lat": 31.7621153,
-    "geo_long": -95.6307891,
-    "latitude": 32.2174363,
-    "longitude": 35.2567915
+    "geo_lat": 31.517,
+    "geo_long": 34.450,
+    "latitude": 31.517,
+    "longitude": 34.450
   },
   {
     "id": "Akaku53.us",
@@ -1292,14 +1292,14 @@
     "name": "Al Aqsa Channel (416p) [Not 24/7]",
     "url": "http://167.172.161.13/hls/feedspare/6udfi7v8a3eof6nlps6e9ovfrs65c7l7.m3u8",
     "logo": "https://i.imgur.com/Z2rfrQ8.png",
-    "country": "Unknown",
-    "city": "Al Aqsa Channel 416p Not 247",
+    "country": "Palestine",
+    "city": "Gaza",
     "categories": "General",
     "type": "tv",
-    "geo_lat": 31.7621153,
-    "geo_long": -95.6307891,
-    "latitude": 31.5017,
-    "longitude": 34.4668
+    "geo_lat": 31.517,
+    "geo_long": 34.450,
+    "latitude": 31.517,
+    "longitude": 34.450
   },
   {
     "id": "AlDafrahTV.ae",


### PR DESCRIPTION
This commit addresses the issue of incorrect station locations, including a large grid of stations in the Atlantic Ocean.

After several attempts with automated scripts, it was determined that the data quality for many stations was too poor for an automated solution to be 100% effective. This commit reflects a manual and semi-automated process to fix the station locations.

The key changes are:
- Manually researched and updated the coordinates for a large number of stations that were previously in the Atlantic Ocean or had other incorrect coordinates.
- Restored and improved the original `fixAndGeocodeStations.js` script, which contains logic to handle the specific data quality issues in this project.
- The script now correctly targets the `...Fixed.json` files that the application uses.
- The station data files (`tvStationsWithUrlsFixed.json` and `radioStationsFixed.json`) have been updated with the corrected coordinates.
- Redundant and confusing scripts have been deleted and `package.json` has been cleaned up.

While the vast majority of stations have been fixed, a small number of stations could not be geocoded due to a complete lack of location information in their names or metadata.