### PR TITLE
Fix station locations and improve geocoding script

### DIFF
--- a/geocodeStations.js
+++ b/geocodeStations.js
@@ -1,6 +1,25 @@
 import fs from 'fs/promises';
 import axios from 'axios';
 
+// Function to extract country from station ID
+function getCountryFromId(stationId) {
+  const parts = stationId.split('.');
+  if (parts.length > 1) {
+    const countryCode = parts[parts.length - 1].split('@')[0];
+    // Simple mapping for some common codes
+    const countryMap = {
+      'uk': 'United Kingdom',
+      'cr': 'Costa Rica',
+      'do': 'Dominican Republic',
+      'be': 'Belgium',
+      'pr': 'Puerto Rico',
+      'gt': 'Guatemala',
+    };
+    return countryMap[countryCode.toLowerCase()] || null;
+  }
+  return null;
+}
+
 // Function to geocode a location using OpenStreetMap Nominatim
 async function geocodeLocation(city, country) {
   try {
@@ -76,17 +95,20 @@ async function fixTVStations() {
         (station.geo_lat === 42 && station.geo_long === -100) ||
         (station.geo_lat === 12.4989994 && station.geo_long === 124.6746741) ||
         (station.geo_lat === 0 && station.geo_long === 0) ||
+        (station.geo_lat > 20 && station.geo_lat < 60 && station.geo_long > -80 && station.geo_long < -20) ||
         (station.geo_lat >= -90 && station.geo_lat <= 90 && station.geo_long >= -180 && station.geo_long <= 180) === false;
       
-      // Check if we have valid country information
-      const hasValidCountry = station.country && station.country !== 'Unknown' && station.country.trim() !== '';
-      
-      // Try to geocode if coordinates are placeholders and we have a valid country
-      if (isPlaceholderCoord && hasValidCountry) {
+      // Try to geocode if coordinates are placeholders
+      if (isPlaceholderCoord) {
         stationsToGeocode++;
         
+        let country = station.country;
+        if (country === 'Unknown') {
+          country = getCountryFromId(station.id);
+        }
+
         // Create a cache key using country (and city if available)
-        const cacheKey = `${station.city || ''}|${station.country}`;
+        const cacheKey = `${station.city || ''}|${country}`;
         
         // Check if we already have this location geocoded
         if (geocodedCache.has(cacheKey)) {
@@ -99,28 +121,28 @@ async function fixTVStations() {
           }
         } else {
           // Try to geocode this location
-          const coords = await geocodeLocation(station.city, station.country);
+          const coords = await geocodeLocation(station.city, country);
           geocodedCache.set(cacheKey, coords);
           
           if (coords) {
             station.geo_lat = coords.latitude;
             station.geo_long = coords.longitude;
             geocodedStations++;
-            console.log(`Geocoded ${station.city || 'Unknown City'}, ${station.country}: ${coords.latitude}, ${coords.longitude}`);
+            console.log(`Geocoded ${station.city || 'Unknown City'}, ${country}: ${coords.latitude}, ${coords.longitude}`);
           } else {
             // If we failed to geocode with city+country, try just the country
-            if (station.country && station.country !== 'Unknown') {
-              const countryCoords = await geocodeLocation(null, station.country);
+            if (country && country !== 'Unknown') {
+              const countryCoords = await geocodeLocation(null, country);
               if (countryCoords) {
                 station.geo_lat = countryCoords.latitude;
                 station.geo_long = countryCoords.longitude;
                 geocodedStations++;
-                console.log(`Geocoded country ${station.country}: ${countryCoords.latitude}, ${countryCoords.longitude}`);
+                console.log(`Geocoded country ${country}: ${countryCoords.latitude}, ${countryCoords.longitude}`);
               } else {
-                console.log(`Failed to geocode ${station.city || 'Unknown City'}, ${station.country}`);
+                console.log(`Failed to geocode ${station.city || 'Unknown City'}, ${country}`);
               }
             } else {
-              console.log(`Failed to geocode ${station.city || 'Unknown City'}, ${station.country}`);
+              console.log(`Failed to geocode ${station.city || 'Unknown City'}, ${country}`);
             }
           }
           
@@ -134,9 +156,9 @@ async function fixTVStations() {
     console.log(`Successfully geocoded: ${geocodedStations}`);
     
     // Write the fixed data back to the file
-    await fs.writeFile('./src/data/tvStationsWithUrlsFixed.json', JSON.stringify(tvStations, null, 2));
+    await fs.writeFile('./src/data/tvStationsWithUrls.json', JSON.stringify(tvStations, null, 2));
     
-    console.log('Fixed TV stations data saved to tvStationsWithUrlsFixed.json');
+    console.log('Fixed TV stations data saved to tvStationsWithUrls.json');
   } catch (error) {
     console.error('Error fixing TV station coordinates:', error);
   }
@@ -162,35 +184,18 @@ async function fixRadioStations() {
     for (let i = 0; i < radioStations.length; i++) {
       const station = radioStations[i];
       
-      // Check if coordinates are placeholder values (0,0) or other common placeholders
-      const isPlaceholderCoord = 
-        (station.geo_lat == 0 && station.geo_long == 0) ||
-        (station.geo_lat === 40 && station.geo_long === -100) ||
-        (station.geo_lat === 42 && station.geo_long === -100) ||
-        (station.geo_lat === 12.4989994 && station.geo_long === 124.6746741) ||
-        (station.geo_lat >= -90 && station.geo_lat <= 90 && station.geo_long >= -180 && station.geo_long <= 180) === false;
+      // Check if coordinates are placeholder values (0,0)
+      const isPlaceholderCoord = station.geo_lat == 0 && station.geo_long == 0;
       
-      // Check if we have valid location information
-      const hasValidLocation = 
-        (station.country && station.country !== 'Unknown' && station.country.trim() !== '') ||
-        (station.state && station.state !== 'Unknown' && station.state.trim() !== '') ||
-        (station.city && station.city !== 'Unknown' && station.city.trim() !== '');
-      
-      // Try to geocode if coordinates are placeholders and we have valid location info
-      if (isPlaceholderCoord && hasValidLocation) {
+      // If we have city/country info and coordinates are placeholders, try to geocode
+      if ((station.city || station.state || station.country) && isPlaceholderCoord) {
         stationsToGeocode++;
         
-        // Create a cache key using available location information
+        // Create a cache key
         const locationParts = [];
-        if (station.city && station.city !== 'Unknown') {
-          locationParts.push(station.city);
-        }
-        if (station.state && station.state !== 'Unknown') {
-          locationParts.push(station.state);
-        }
-        if (station.country && station.country !== 'Unknown') {
-          locationParts.push(station.country);
-        }
+        if (station.city) locationParts.push(station.city);
+        if (station.state) locationParts.push(station.state);
+        if (station.country) locationParts.push(station.country);
         const cacheKey = locationParts.join('|');
         
         // Check if we already have this location geocoded
@@ -204,34 +209,7 @@ async function fixRadioStations() {
           }
         } else {
           // Try to geocode this location
-          // Try different combinations of location information
-          let coords = null;
-          
-          // Try city + country first
-          if (station.city && station.city !== 'Unknown' && station.country && station.country !== 'Unknown') {
-            coords = await geocodeLocation(station.city, station.country);
-          }
-          
-          // Try state + country if that failed
-          if (!coords && station.state && station.state !== 'Unknown' && station.country && station.country !== 'Unknown') {
-            coords = await geocodeLocation(station.state, station.country);
-          }
-          
-          // Try just city if that failed
-          if (!coords && station.city && station.city !== 'Unknown') {
-            coords = await geocodeLocation(station.city, null);
-          }
-          
-          // Try just state if that failed
-          if (!coords && station.state && station.state !== 'Unknown') {
-            coords = await geocodeLocation(station.state, null);
-          }
-          
-          // Try just country if that failed
-          if (!coords && station.country && station.country !== 'Unknown') {
-            coords = await geocodeLocation(null, station.country);
-          }
-          
+          const coords = await geocodeLocation(station.city || station.state, station.country);
           geocodedCache.set(cacheKey, coords);
           
           if (coords) {
@@ -244,7 +222,7 @@ async function fixRadioStations() {
           }
           
           // Add a small delay to respect API rate limits
-          await new Promise(resolve => setTimeout(resolve, 500));
+          await new Promise(resolve => setTimeout(resolve, 1000));
         }
       }
     }
@@ -253,9 +231,9 @@ async function fixRadioStations() {
     console.log(`Successfully geocoded: ${geocodedStations}`);
     
     // Write the fixed data back to the file
-    await fs.writeFile('./src/data/radioStationsFixed.json', JSON.stringify(radioStations, null, 2));
+    await fs.writeFile('./src/data/radioStations.json', JSON.stringify(radioStations, null, 2));
     
-    console.log('Fixed radio stations data saved to radioStationsFixed.json');
+    console.log('Fixed radio stations data saved to radioStations.json');
   } catch (error) {
     console.error('Error fixing radio station coordinates:', error);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2868,9 +2868,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.49.0.tgz",
-      "integrity": "sha512-rlKIeL854Ed0e09QGYFlmDNbka6I3EQFw7iZuugQjMb11KMpJCLPFL4ZPbMfaEhLADEL1yx0oujGkBQ7+qW3eA==",
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.50.0.tgz",
+      "integrity": "sha512-lVgpeQyy4fWN5QYebtW4buT/4kn4p4IJ+kDNB4uYNT5b8c8DLJDg6titg20NIg7E8RWwdWZORW6vUFfrLyG3KQ==",
       "cpu": [
         "arm"
       ],
@@ -2882,9 +2882,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.49.0.tgz",
-      "integrity": "sha512-cqPpZdKUSQYRtLLr6R4X3sD4jCBO1zUmeo3qrWBCqYIeH8Q3KRL4F3V7XJ2Rm8/RJOQBZuqzQGWPjjvFUcYa/w==",
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.50.0.tgz",
+      "integrity": "sha512-2O73dR4Dc9bp+wSYhviP6sDziurB5/HCym7xILKifWdE9UsOe2FtNcM+I4xZjKrfLJnq5UR8k9riB87gauiQtw==",
       "cpu": [
         "arm64"
       ],
@@ -2896,9 +2896,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.49.0.tgz",
-      "integrity": "sha512-99kMMSMQT7got6iYX3yyIiJfFndpojBmkHfTc1rIje8VbjhmqBXE+nb7ZZP3A5skLyujvT0eIUCUsxAe6NjWbw==",
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.50.0.tgz",
+      "integrity": "sha512-vwSXQN8T4sKf1RHr1F0s98Pf8UPz7pS6P3LG9NSmuw0TVh7EmaE+5Ny7hJOZ0M2yuTctEsHHRTMi2wuHkdS6Hg==",
       "cpu": [
         "arm64"
       ],
@@ -2910,9 +2910,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.49.0.tgz",
-      "integrity": "sha512-y8cXoD3wdWUDpjOLMKLx6l+NFz3NlkWKcBCBfttUn+VGSfgsQ5o/yDUGtzE9HvsodkP0+16N0P4Ty1VuhtRUGg==",
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.50.0.tgz",
+      "integrity": "sha512-cQp/WG8HE7BCGyFVuzUg0FNmupxC+EPZEwWu2FCGGw5WDT1o2/YlENbm5e9SMvfDFR6FRhVCBePLqj0o8MN7Vw==",
       "cpu": [
         "x64"
       ],
@@ -2924,9 +2924,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.49.0.tgz",
-      "integrity": "sha512-3mY5Pr7qv4GS4ZvWoSP8zha8YoiqrU+e0ViPvB549jvliBbdNLrg2ywPGkgLC3cmvN8ya3za+Q2xVyT6z+vZqA==",
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.50.0.tgz",
+      "integrity": "sha512-UR1uTJFU/p801DvvBbtDD7z9mQL8J80xB0bR7DqW7UGQHRm/OaKzp4is7sQSdbt2pjjSS72eAtRh43hNduTnnQ==",
       "cpu": [
         "arm64"
       ],
@@ -2938,9 +2938,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.49.0.tgz",
-      "integrity": "sha512-C9KzzOAQU5gU4kG8DTk+tjdKjpWhVWd5uVkinCwwFub2m7cDYLOdtXoMrExfeBmeRy9kBQMkiyJ+HULyF1yj9w==",
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.50.0.tgz",
+      "integrity": "sha512-G/DKyS6PK0dD0+VEzH/6n/hWDNPDZSMBmqsElWnCRGrYOb2jC0VSupp7UAHHQ4+QILwkxSMaYIbQ72dktp8pKA==",
       "cpu": [
         "x64"
       ],
@@ -2952,9 +2952,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.49.0.tgz",
-      "integrity": "sha512-OVSQgEZDVLnTbMq5NBs6xkmz3AADByCWI4RdKSFNlDsYXdFtlxS59J+w+LippJe8KcmeSSM3ba+GlsM9+WwC1w==",
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.50.0.tgz",
+      "integrity": "sha512-u72Mzc6jyJwKjJbZZcIYmd9bumJu7KNmHYdue43vT1rXPm2rITwmPWF0mmPzLm9/vJWxIRbao/jrQmxTO0Sm9w==",
       "cpu": [
         "arm"
       ],
@@ -2966,9 +2966,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.49.0.tgz",
-      "integrity": "sha512-ZnfSFA7fDUHNa4P3VwAcfaBLakCbYaxCk0jUnS3dTou9P95kwoOLAMlT3WmEJDBCSrOEFFV0Y1HXiwfLYJuLlA==",
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.50.0.tgz",
+      "integrity": "sha512-S4UefYdV0tnynDJV1mdkNawp0E5Qm2MtSs330IyHgaccOFrwqsvgigUD29uT+B/70PDY1eQ3t40+xf6wIvXJyg==",
       "cpu": [
         "arm"
       ],
@@ -2980,9 +2980,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.49.0.tgz",
-      "integrity": "sha512-Z81u+gfrobVK2iV7GqZCBfEB1y6+I61AH466lNK+xy1jfqFLiQ9Qv716WUM5fxFrYxwC7ziVdZRU9qvGHkYIJg==",
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.50.0.tgz",
+      "integrity": "sha512-1EhkSvUQXJsIhk4msxP5nNAUWoB4MFDHhtc4gAYvnqoHlaL9V3F37pNHabndawsfy/Tp7BPiy/aSa6XBYbaD1g==",
       "cpu": [
         "arm64"
       ],
@@ -2994,9 +2994,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.49.0.tgz",
-      "integrity": "sha512-zoAwS0KCXSnTp9NH/h9aamBAIve0DXeYpll85shf9NJ0URjSTzzS+Z9evmolN+ICfD3v8skKUPyk2PO0uGdFqg==",
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.50.0.tgz",
+      "integrity": "sha512-EtBDIZuDtVg75xIPIK1l5vCXNNCIRM0OBPUG+tbApDuJAy9mKago6QxX+tfMzbCI6tXEhMuZuN1+CU8iDW+0UQ==",
       "cpu": [
         "arm64"
       ],
@@ -3008,9 +3008,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.49.0.tgz",
-      "integrity": "sha512-2QyUyQQ1ZtwZGiq0nvODL+vLJBtciItC3/5cYN8ncDQcv5avrt2MbKt1XU/vFAJlLta5KujqyHdYtdag4YEjYQ==",
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.50.0.tgz",
+      "integrity": "sha512-BGYSwJdMP0hT5CCmljuSNx7+k+0upweM2M4YGfFBjnFSZMHOLYR0gEEj/dxyYJ6Zc6AiSeaBY8dWOa11GF/ppQ==",
       "cpu": [
         "loong64"
       ],
@@ -3022,9 +3022,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.49.0.tgz",
-      "integrity": "sha512-k9aEmOWt+mrMuD3skjVJSSxHckJp+SiFzFG+v8JLXbc/xi9hv2icSkR3U7uQzqy+/QbbYY7iNB9eDTwrELo14g==",
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.50.0.tgz",
+      "integrity": "sha512-I1gSMzkVe1KzAxKAroCJL30hA4DqSi+wGc5gviD0y3IL/VkvcnAqwBf4RHXHyvH66YVHxpKO8ojrgc4SrWAnLg==",
       "cpu": [
         "ppc64"
       ],
@@ -3036,9 +3036,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.49.0.tgz",
-      "integrity": "sha512-rDKRFFIWJ/zJn6uk2IdYLc09Z7zkE5IFIOWqpuU0o6ZpHcdniAyWkwSUWE/Z25N/wNDmFHHMzin84qW7Wzkjsw==",
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.50.0.tgz",
+      "integrity": "sha512-bSbWlY3jZo7molh4tc5dKfeSxkqnf48UsLqYbUhnkdnfgZjgufLS/NTA8PcP/dnvct5CCdNkABJ56CbclMRYCA==",
       "cpu": [
         "riscv64"
       ],
@@ -3050,9 +3050,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.49.0.tgz",
-      "integrity": "sha512-FkkhIY/hYFVnOzz1WeV3S9Bd1h0hda/gRqvZCMpHWDHdiIHn6pqsY3b5eSbvGccWHMQ1uUzgZTKS4oGpykf8Tw==",
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.50.0.tgz",
+      "integrity": "sha512-LSXSGumSURzEQLT2e4sFqFOv3LWZsEF8FK7AAv9zHZNDdMnUPYH3t8ZlaeYYZyTXnsob3htwTKeWtBIkPV27iQ==",
       "cpu": [
         "riscv64"
       ],
@@ -3064,9 +3064,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.49.0.tgz",
-      "integrity": "sha512-gRf5c+A7QiOG3UwLyOOtyJMD31JJhMjBvpfhAitPAoqZFcOeK3Kc1Veg1z/trmt+2P6F/biT02fU19GGTS529A==",
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.50.0.tgz",
+      "integrity": "sha512-CxRKyakfDrsLXiCyucVfVWVoaPA4oFSpPpDwlMcDFQvrv3XY6KEzMtMZrA+e/goC8xxp2WSOxHQubP8fPmmjOQ==",
       "cpu": [
         "s390x"
       ],
@@ -3078,9 +3078,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.49.0.tgz",
-      "integrity": "sha512-BR7+blScdLW1h/2hB/2oXM+dhTmpW3rQt1DeSiCP9mc2NMMkqVgjIN3DDsNpKmezffGC9R8XKVOLmBkRUcK/sA==",
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.50.0.tgz",
+      "integrity": "sha512-8PrJJA7/VU8ToHVEPu14FzuSAqVKyo5gg/J8xUerMbyNkWkO9j2ExBho/68RnJsMGNJq4zH114iAttgm7BZVkA==",
       "cpu": [
         "x64"
       ],
@@ -3092,9 +3092,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.49.0.tgz",
-      "integrity": "sha512-hDMOAe+6nX3V5ei1I7Au3wcr9h3ktKzDvF2ne5ovX8RZiAHEtX1A5SNNk4zt1Qt77CmnbqT+upb/umzoPMWiPg==",
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.50.0.tgz",
+      "integrity": "sha512-SkE6YQp+CzpyOrbw7Oc4MgXFvTw2UIBElvAvLCo230pyxOLmYwRPwZ/L5lBe/VW/qT1ZgND9wJfOsdy0XptRvw==",
       "cpu": [
         "x64"
       ],
@@ -3105,10 +3105,24 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.50.0.tgz",
+      "integrity": "sha512-PZkNLPfvXeIOgJWA804zjSFH7fARBBCpCXxgkGDRjjAhRLOR8o0IGS01ykh5GYfod4c2yiiREuDM8iZ+pVsT+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.49.0.tgz",
-      "integrity": "sha512-wkNRzfiIGaElC9kXUT+HLx17z7D0jl+9tGYRKwd8r7cUqTL7GYAvgUY++U2hK6Ar7z5Z6IRRoWC8kQxpmM7TDA==",
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.50.0.tgz",
+      "integrity": "sha512-q7cIIdFvWQoaCbLDUyUc8YfR3Jh2xx3unO8Dn6/TTogKjfwrax9SyfmGGK6cQhKtjePI7jRfd7iRYcxYs93esg==",
       "cpu": [
         "arm64"
       ],
@@ -3120,9 +3134,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.49.0.tgz",
-      "integrity": "sha512-gq5aW/SyNpjp71AAzroH37DtINDcX1Qw2iv9Chyz49ZgdOP3NV8QCyKZUrGsYX9Yyggj5soFiRCgsL3HwD8TdA==",
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.50.0.tgz",
+      "integrity": "sha512-XzNOVg/YnDOmFdDKcxxK410PrcbcqZkBmz+0FicpW5jtjKQxcW1BZJEQOF0NJa6JO7CZhett8GEtRN/wYLYJuw==",
       "cpu": [
         "ia32"
       ],
@@ -3134,9 +3148,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.49.0.tgz",
-      "integrity": "sha512-gEtqFbzmZLFk2xKh7g0Rlo8xzho8KrEFEkzvHbfUGkrgXOpZ4XagQ6n+wIZFNh1nTb8UD16J4nFSFKXYgnbdBg==",
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.50.0.tgz",
+      "integrity": "sha512-xMmiWRR8sp72Zqwjgtf3QbZfF1wdh8X2ABu3EaozvZcyHJeU0r+XAnXdKgs4cCAp6ORoYoCygipYP1mjmbjrsg==",
       "cpu": [
         "x64"
       ],
@@ -6083,42 +6097,19 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.49.0.tgz",
-      "integrity": "sha512-3IVq0cGJ6H7fKXXEdVt+RcYvRCt8beYY9K1760wGQwSAHZcS9eot1zDG5axUbcp/kWRi5zKIIDX8MoKv/TzvZA==",
+      "version": "2.79.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
+      "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@types/estree": "1.0.8"
-      },
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
+        "node": ">=10.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.49.0",
-        "@rollup/rollup-android-arm64": "4.49.0",
-        "@rollup/rollup-darwin-arm64": "4.49.0",
-        "@rollup/rollup-darwin-x64": "4.49.0",
-        "@rollup/rollup-freebsd-arm64": "4.49.0",
-        "@rollup/rollup-freebsd-x64": "4.49.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.49.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.49.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.49.0",
-        "@rollup/rollup-linux-arm64-musl": "4.49.0",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.49.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.49.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.49.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.49.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.49.0",
-        "@rollup/rollup-linux-x64-gnu": "4.49.0",
-        "@rollup/rollup-linux-x64-musl": "4.49.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.49.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.49.0",
-        "@rollup/rollup-win32-x64-msvc": "4.49.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -6813,6 +6804,47 @@
       "peerDependencies": {
         "cesium": "^1.95.0",
         "vite": ">=2.7.1"
+      }
+    },
+    "node_modules/vite/node_modules/rollup": {
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.50.0.tgz",
+      "integrity": "sha512-/Zl4D8zPifNmyGzJS+3kVoyXeDeT/GrsJM94sACNg9RtUE0hrHa1bNPtRSrfHTMH5HjRzce6K7rlTh3Khiw+pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.50.0",
+        "@rollup/rollup-android-arm64": "4.50.0",
+        "@rollup/rollup-darwin-arm64": "4.50.0",
+        "@rollup/rollup-darwin-x64": "4.50.0",
+        "@rollup/rollup-freebsd-arm64": "4.50.0",
+        "@rollup/rollup-freebsd-x64": "4.50.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.50.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.50.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.50.0",
+        "@rollup/rollup-linux-arm64-musl": "4.50.0",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.50.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.50.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.50.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.50.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.50.0",
+        "@rollup/rollup-linux-x64-gnu": "4.50.0",
+        "@rollup/rollup-linux-x64-musl": "4.50.0",
+        "@rollup/rollup-openharmony-arm64": "4.50.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.50.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.50.0",
+        "@rollup/rollup-win32-x64-msvc": "4.50.0",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/wrap-ansi": {

--- a/src/data/radioStations.json.bak
+++ b/src/data/radioStations.json.bak
@@ -17,9 +17,7 @@
     "votes": 752759,
     "clickcount": 14057,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 51.1638175,
-    "longitude": 10.4478313
+    "type": "radio"
   },
   {
     "stationuuid": "9617a958-0601-11e8-ae97-52543be04c81",
@@ -39,9 +37,7 @@
     "votes": 248649,
     "clickcount": 12244,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 32.7288179,
-    "longitude": -117.1528184
+    "type": "radio"
   },
   {
     "stationuuid": "d28420a4-eccf-47a2-ace1-088c7e7cb7e0",
@@ -61,9 +57,7 @@
     "votes": 73481,
     "clickcount": 11203,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 32.7288179,
-    "longitude": -117.1528184
+    "type": "radio"
   },
   {
     "stationuuid": "1c3e8be2-5b14-4933-bad3-87cbc227cba4",
@@ -83,9 +77,7 @@
     "votes": 7119,
     "clickcount": 9257,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 51.1638175,
-    "longitude": 10.4478313
+    "type": "radio"
   },
   {
     "stationuuid": "962cc6df-0601-11e8-ae97-52543be04c81",
@@ -105,9 +97,7 @@
     "votes": 514115,
     "clickcount": 8094,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 47.1817585,
-    "longitude": 19.5060937
+    "type": "radio"
   },
   {
     "stationuuid": "1cfb151d-a341-11e9-a787-52543be04c81",
@@ -127,9 +117,7 @@
     "votes": 73968,
     "clickcount": 7352,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 46.603354,
-    "longitude": 1.8883335
+    "type": "radio"
   },
   {
     "stationuuid": "902ea231-d537-4dc8-8708-6819418086d0",
@@ -149,9 +137,7 @@
     "votes": 11350,
     "clickcount": 7063,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 22.3511148,
-    "longitude": 78.6677428
+    "type": "radio"
   },
   {
     "stationuuid": "c17ec87a-3063-40b0-834c-a2991ca074b9",
@@ -171,9 +157,7 @@
     "votes": 10767,
     "clickcount": 6426,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 14.1483443,
-    "longitude": 121.3119391
+    "type": "radio"
   },
   {
     "stationuuid": "240d28b9-7858-48d2-a816-9cf8e1875fe8",
@@ -193,9 +177,7 @@
     "votes": 15063,
     "clickcount": 6412,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 51.1638175,
-    "longitude": 10.4478313
+    "type": "radio"
   },
   {
     "stationuuid": "960b9e98-0601-11e8-ae97-52543be04c81",
@@ -215,9 +197,7 @@
     "votes": 48005,
     "clickcount": 6195,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 64.6863136,
-    "longitude": 97.7453061
+    "type": "radio"
   },
   {
     "stationuuid": "dc722c5e-21a0-49be-8687-474638c95ca7",
@@ -237,9 +217,7 @@
     "votes": 8991,
     "clickcount": 5776,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 35.000074,
-    "longitude": 104.999927
+    "type": "radio"
   },
   {
     "stationuuid": "9606f727-0601-11e8-ae97-52543be04c81",
@@ -259,9 +237,7 @@
     "votes": 27652,
     "clickcount": 5201,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 51.1638175,
-    "longitude": 10.4478313
+    "type": "radio"
   },
   {
     "stationuuid": "9605edb3-0601-11e8-ae97-52543be04c81",
@@ -281,9 +257,7 @@
     "votes": 21186,
     "clickcount": 5182,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 51.1638175,
-    "longitude": 10.4478313
+    "type": "radio"
   },
   {
     "stationuuid": "9622cd46-0601-11e8-ae97-52543be04c81",
@@ -303,9 +277,7 @@
     "votes": 52624,
     "clickcount": 4899,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 85,
-    "longitude": -120
+    "type": "radio"
   },
   {
     "stationuuid": "f592bcd7-c052-11e9-8502-52543be04c81",
@@ -325,9 +297,7 @@
     "votes": 380399,
     "clickcount": 4812,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 26.492533,
-    "longitude": 92.3308789
+    "type": "radio"
   },
   {
     "stationuuid": "df6a8fa4-23cb-4279-a025-bf3057bd0a4b",
@@ -347,9 +317,7 @@
     "votes": 1431,
     "clickcount": 4631,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 4.5693754,
-    "longitude": 102.2656823
+    "type": "radio"
   },
   {
     "stationuuid": "95eff2f9-cb7a-4fe4-bb07-8c700719f8b6",
@@ -369,9 +337,7 @@
     "votes": 1520,
     "clickcount": 4615,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 64.6863136,
-    "longitude": 97.7453061
+    "type": "radio"
   },
   {
     "stationuuid": "98137c2d-ce68-4e33-8cb7-ddf3692ecc9d",
@@ -391,9 +357,7 @@
     "votes": 1981,
     "clickcount": 4469,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 52.4577754,
-    "longitude": -1.8692099
+    "type": "radio"
   },
   {
     "stationuuid": "399b7c2a-6680-11e8-b15b-52543be04c81",
@@ -413,9 +377,7 @@
     "votes": 52746,
     "clickcount": 4356,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 52.215933,
-    "longitude": 19.134422
+    "type": "radio"
   },
   {
     "stationuuid": "2bf82625-6e78-445d-afff-e51e53c369a9",
@@ -435,9 +397,7 @@
     "votes": 11965,
     "clickcount": 4210,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 35.000074,
-    "longitude": 104.999927
+    "type": "radio"
   },
   {
     "stationuuid": "964fade0-0601-11e8-ae97-52543be04c81",
@@ -457,9 +417,7 @@
     "votes": 48008,
     "clickcount": 4065,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 55.7497417,
-    "longitude": 37.6022613
+    "type": "radio"
   },
   {
     "stationuuid": "932eb148-e6f6-11e9-a96c-52543be04c81",
@@ -479,9 +437,7 @@
     "votes": 35473,
     "clickcount": 3847,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 46.603354,
-    "longitude": 1.8883335
+    "type": "radio"
   },
   {
     "stationuuid": "63688c44-e90b-11e8-a471-52543be04c81",
@@ -501,9 +457,7 @@
     "votes": 48653,
     "clickcount": 3746,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 64.6863136,
-    "longitude": 97.7453061
+    "type": "radio"
   },
   {
     "stationuuid": "604bb4af-ccf6-47bd-819e-7d1accd15e05",
@@ -523,9 +477,7 @@
     "votes": 2835,
     "clickcount": 3729,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 14.1483443,
-    "longitude": 121.3119391
+    "type": "radio"
   },
   {
     "stationuuid": "5a6946a2-f02f-4fd1-a16b-558c90150041",
@@ -545,9 +497,7 @@
     "votes": 1204,
     "clickcount": 3661,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 51.1638175,
-    "longitude": 10.4478313
+    "type": "radio"
   },
   {
     "stationuuid": "d2bbffaf-5d67-4a65-9772-097d8c0269d3",
@@ -567,9 +517,7 @@
     "votes": 53864,
     "clickcount": 3605,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 46.603354,
-    "longitude": 1.8883335
+    "type": "radio"
   },
   {
     "stationuuid": "960c2914-0601-11e8-ae97-52543be04c81",
@@ -589,9 +537,7 @@
     "votes": 73333,
     "clickcount": 3534,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 46.603354,
-    "longitude": 1.8883335
+    "type": "radio"
   },
   {
     "stationuuid": "6a1440b2-e6f0-11e9-a96c-52543be04c81",
@@ -611,9 +557,7 @@
     "votes": 47928,
     "clickcount": 3486,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 46.603354,
-    "longitude": 1.8883335
+    "type": "radio"
   },
   {
     "stationuuid": "962dc110-0601-11e8-ae97-52543be04c81",
@@ -633,9 +577,7 @@
     "votes": 25350,
     "clickcount": 3166,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 53.5140296,
-    "longitude": 10.2480924
+    "type": "radio"
   },
   {
     "stationuuid": "33960c43-0464-44b4-abfa-73591ebf647f",
@@ -655,9 +597,7 @@
     "votes": 4459,
     "clickcount": 3113,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 46.603354,
-    "longitude": 1.8883335
+    "type": "radio"
   },
   {
     "stationuuid": "a4e79d4f-8c40-46a4-bd5b-37c5266ae8e8",
@@ -677,9 +617,7 @@
     "votes": 316,
     "clickcount": 3109,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 4.5693754,
-    "longitude": 102.2656823
+    "type": "radio"
   },
   {
     "stationuuid": "f796d445-4314-4eb6-a09d-bcac5d474661",
@@ -699,9 +637,7 @@
     "votes": 47921,
     "clickcount": 3096,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 64.6863136,
-    "longitude": 97.7453061
+    "type": "radio"
   },
   {
     "stationuuid": "9627ddc0-0601-11e8-ae97-52543be04c81",
@@ -721,9 +657,7 @@
     "votes": 47934,
     "clickcount": 3088,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 36.1337324,
-    "longitude": -80.2782636
+    "type": "radio"
   },
   {
     "stationuuid": "960594a6-0601-11e8-ae97-52543be04c81",
@@ -743,9 +677,7 @@
     "votes": 21321,
     "clickcount": 3086,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 51.1638175,
-    "longitude": 10.4478313
+    "type": "radio"
   },
   {
     "stationuuid": "961b7325-0601-11e8-ae97-52543be04c81",
@@ -765,9 +697,7 @@
     "votes": 48032,
     "clickcount": 3080,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 36.1337324,
-    "longitude": -80.2782636
+    "type": "radio"
   },
   {
     "stationuuid": "d377fdb9-9136-47de-a1f4-6b02a1bc7f72",
@@ -787,9 +717,7 @@
     "votes": 4208,
     "clickcount": 3039,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 52.215933,
-    "longitude": 19.134422
+    "type": "radio"
   },
   {
     "stationuuid": "aa408a3b-3d07-415d-8af1-a60b64e07043",
@@ -809,9 +737,7 @@
     "votes": 32490,
     "clickcount": 2956,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 32.6475314,
-    "longitude": 54.5643516
+    "type": "radio"
   },
   {
     "stationuuid": "7dd71b85-139b-4362-81b1-4206133a517c",
@@ -831,9 +757,7 @@
     "votes": 4318,
     "clickcount": 2935,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 22.3511148,
-    "longitude": 78.6677428
+    "type": "radio"
   },
   {
     "stationuuid": "9a8f7fb5-3159-11ea-afca-52543be04c81",
@@ -853,9 +777,7 @@
     "votes": 15754,
     "clickcount": 2933,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 1.5333554,
-    "longitude": 32.2166578
+    "type": "radio"
   },
   {
     "stationuuid": "1b762b21-2ec6-412a-a231-fa34a96f4f99",
@@ -875,9 +797,7 @@
     "votes": 2669,
     "clickcount": 2926,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 51.1638175,
-    "longitude": 10.4478313
+    "type": "radio"
   },
   {
     "stationuuid": "986c5985-41d7-11ea-a95e-52543be04c81",
@@ -897,9 +817,7 @@
     "votes": 27609,
     "clickcount": 2792,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 42.6384261,
-    "longitude": 12.674297
+    "type": "radio"
   },
   {
     "stationuuid": "9e8ccaf9-99b1-4b80-ac33-66b3b5057745",
@@ -919,9 +837,7 @@
     "votes": 260,
     "clickcount": 2778,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": -28.8166236,
-    "longitude": 24.991639
+    "type": "radio"
   },
   {
     "stationuuid": "a0d30a64-51e5-11e8-a4d1-52543be04c81",
@@ -941,9 +857,7 @@
     "votes": 49703,
     "clickcount": 2764,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 80,
-    "longitude": -100
+    "type": "radio"
   },
   {
     "stationuuid": "18570040-960a-4f41-96dc-fe47d5878dd1",
@@ -963,9 +877,7 @@
     "votes": 4145,
     "clickcount": 2756,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 85,
-    "longitude": -100
+    "type": "radio"
   },
   {
     "stationuuid": "961c96ef-0601-11e8-ae97-52543be04c81",
@@ -985,9 +897,7 @@
     "votes": 50620,
     "clickcount": 2744,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 90,
-    "longitude": -100
+    "type": "radio"
   },
   {
     "stationuuid": "96126f56-0601-11e8-ae97-52543be04c81",
@@ -1007,9 +917,7 @@
     "votes": 15257,
     "clickcount": 2740,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 52.2434979,
-    "longitude": 5.6343227
+    "type": "radio"
   },
   {
     "stationuuid": "96126e82-0601-11e8-ae97-52543be04c81",
@@ -1029,9 +937,7 @@
     "votes": 10222,
     "clickcount": 2732,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 52.2434979,
-    "longitude": 5.6343227
+    "type": "radio"
   },
   {
     "stationuuid": "961d5c4e-0601-11e8-ae97-52543be04c81",
@@ -1051,9 +957,7 @@
     "votes": 47894,
     "clickcount": 2702,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 36.1337324,
-    "longitude": -80.2782636
+    "type": "radio"
   },
   {
     "stationuuid": "68d00a44-200c-4c82-b17f-18d777f3b2ee",
@@ -1073,9 +977,7 @@
     "votes": 3075,
     "clickcount": 2694,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 22.3511148,
-    "longitude": 78.6677428
+    "type": "radio"
   },
   {
     "stationuuid": "692a3b69-0f68-11ea-a87e-52543be04c81",
@@ -1095,9 +997,7 @@
     "votes": 22710,
     "clickcount": 2657,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 39.3260685,
-    "longitude": -4.8379791
+    "type": "radio"
   },
   {
     "stationuuid": "563f5559-105c-11e9-a80b-52543be04c81",
@@ -1117,9 +1017,7 @@
     "votes": 47915,
     "clickcount": 2653,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 64.6863136,
-    "longitude": 97.7453061
+    "type": "radio"
   },
   {
     "stationuuid": "0de82079-04e7-407b-b616-e0726eba5244",
@@ -1139,9 +1037,7 @@
     "votes": 3156,
     "clickcount": 2649,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 51.1638175,
-    "longitude": 10.4478313
+    "type": "radio"
   },
   {
     "stationuuid": "f4e89fce-5d97-4e6a-bc72-b5738344dc91",
@@ -1161,9 +1057,7 @@
     "votes": 494,
     "clickcount": 2638,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 4.5693754,
-    "longitude": 102.2656823
+    "type": "radio"
   },
   {
     "stationuuid": "e723f7f8-0db1-4bc5-a64c-64d8377f9f9a",
@@ -1183,9 +1077,7 @@
     "votes": 744,
     "clickcount": 2600,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 47.59397,
-    "longitude": 14.12456
+    "type": "radio"
   },
   {
     "stationuuid": "961d9b63-0601-11e8-ae97-52543be04c81",
@@ -1200,14 +1092,12 @@
     "tags": "country",
     "codec": "MP3",
     "bitrate": 128,
-    "geo_lat": 36.1337324,
-    "geo_long": -80.2782636,
+    "geo_lat": 38.8888884,
+    "geo_long": -77.0405701,
     "votes": 47925,
     "clickcount": 2593,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 38.8888884,
-    "longitude": -77.0405701
+    "type": "radio"
   },
   {
     "stationuuid": "7a3a3989-8f26-44f7-9ae5-fa91e5cf4f9d",
@@ -1227,9 +1117,7 @@
     "votes": 59598,
     "clickcount": 2553,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 46.603354,
-    "longitude": 1.8883335
+    "type": "radio"
   },
   {
     "stationuuid": "119f07c3-81f0-4309-91e8-f46525f0d35d",
@@ -1249,9 +1137,7 @@
     "votes": 1673,
     "clickcount": 2539,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": -28.8166236,
-    "longitude": 24.991639
+    "type": "radio"
   },
   {
     "stationuuid": "c8d92f0d-6b56-46e7-853b-54cf389d1a97",
@@ -1271,9 +1157,7 @@
     "votes": 6853,
     "clickcount": 2536,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 32.6475314,
-    "longitude": 54.5643516
+    "type": "radio"
   },
   {
     "stationuuid": "033fe547-b71c-4ea0-8274-e6522444629c",
@@ -1293,9 +1177,7 @@
     "votes": 25927,
     "clickcount": 2532,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 85,
-    "longitude": -90
+    "type": "radio"
   },
   {
     "stationuuid": "ac81df15-039c-43df-b944-7462426b9db5",
@@ -1315,9 +1197,7 @@
     "votes": 1219,
     "clickcount": 2520,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": -28.8166236,
-    "longitude": 24.991639
+    "type": "radio"
   },
   {
     "stationuuid": "962a1abd-0601-11e8-ae97-52543be04c81",
@@ -1337,9 +1217,7 @@
     "votes": 38908,
     "clickcount": 2517,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 55.7497417,
-    "longitude": 37.6022613
+    "type": "radio"
   },
   {
     "stationuuid": "961fa288-0601-11e8-ae97-52543be04c81",
@@ -1359,9 +1237,7 @@
     "votes": 45525,
     "clickcount": 2508,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 36.1337324,
-    "longitude": -80.2782636
+    "type": "radio"
   },
   {
     "stationuuid": "c93f9c76-2ad4-464d-bff4-7f46e95f2601",
@@ -1381,9 +1257,7 @@
     "votes": 49881,
     "clickcount": 2488,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 36.1337324,
-    "longitude": -80.2782636
+    "type": "radio"
   },
   {
     "stationuuid": "74f507d1-91b7-48d5-af98-d0d7df1b4e9b",
@@ -1403,9 +1277,7 @@
     "votes": 11183,
     "clickcount": 2470,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 26.2540493,
-    "longitude": 29.2675469
+    "type": "radio"
   },
   {
     "stationuuid": "6add27d4-5573-47b4-ae27-1d05834a9a4a",
@@ -1425,9 +1297,7 @@
     "votes": 328,
     "clickcount": 2448,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 52.2434979,
-    "longitude": 5.6343227
+    "type": "radio"
   },
   {
     "stationuuid": "960553a5-0601-11e8-ae97-52543be04c81",
@@ -1447,9 +1317,7 @@
     "votes": 11014,
     "clickcount": 2391,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 51.1638175,
-    "longitude": 10.4478313
+    "type": "radio"
   },
   {
     "stationuuid": "901c92bd-a757-449a-b8ce-652b079fd38a",
@@ -1469,9 +1337,7 @@
     "votes": 869,
     "clickcount": 2331,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": -10.3333333,
-    "longitude": -53.2
+    "type": "radio"
   },
   {
     "stationuuid": "fd059cc5-b538-41c1-ae76-b8778a84c3db",
@@ -1491,9 +1357,7 @@
     "votes": 567,
     "clickcount": 2280,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 52.2434979,
-    "longitude": 5.6343227
+    "type": "radio"
   },
   {
     "stationuuid": "7ce50274-160a-43b6-a023-782897576f9e",
@@ -1513,9 +1377,7 @@
     "votes": 342,
     "clickcount": 2275,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 15.9266657,
-    "longitude": 107.9650855
+    "type": "radio"
   },
   {
     "stationuuid": "247aa6ff-f402-4b81-8ebb-21fa00791ef5",
@@ -1535,9 +1397,7 @@
     "votes": 2002,
     "clickcount": 2248,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 14.1483443,
-    "longitude": 121.3119391
+    "type": "radio"
   },
   {
     "stationuuid": "003d3c6f-e183-11e9-a8ba-52543be04c81",
@@ -1557,9 +1417,7 @@
     "votes": 3225,
     "clickcount": 2215,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 52.2434979,
-    "longitude": 5.6343227
+    "type": "radio"
   },
   {
     "stationuuid": "01683d91-4e1e-4152-b1bc-30f2f1360b98",
@@ -1579,9 +1437,7 @@
     "votes": 1176,
     "clickcount": 2157,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 51.1638175,
-    "longitude": 10.4478313
+    "type": "radio"
   },
   {
     "stationuuid": "960d063e-0601-11e8-ae97-52543be04c81",
@@ -1601,9 +1457,7 @@
     "votes": 15084,
     "clickcount": 2147,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 51.1638175,
-    "longitude": 10.4478313
+    "type": "radio"
   },
   {
     "stationuuid": "165eab56-4a14-11e9-a4d7-52543be04c81",
@@ -1623,9 +1477,7 @@
     "votes": 47980,
     "clickcount": 2141,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 85,
-    "longitude": -80
+    "type": "radio"
   },
   {
     "stationuuid": "960cf833-0601-11e8-ae97-52543be04c81",
@@ -1645,9 +1497,7 @@
     "votes": 43196,
     "clickcount": 2127,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 32.7288179,
-    "longitude": -117.1528184
+    "type": "radio"
   },
   {
     "stationuuid": "7afae7e3-8d06-42f5-b59e-a52d6e09e60e",
@@ -1667,9 +1517,7 @@
     "votes": 2299,
     "clickcount": 2127,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 50.000678,
-    "longitude": -86.000977
+    "type": "radio"
   },
   {
     "stationuuid": "2b3e2f56-7f31-483b-9441-59a3aa13cd88",
@@ -1689,9 +1537,7 @@
     "votes": 4978,
     "clickcount": 2109,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 32.6475314,
-    "longitude": 54.5643516
+    "type": "radio"
   },
   {
     "stationuuid": "948408f4-0060-44fa-a26c-bf313f6c774d",
@@ -1711,9 +1557,7 @@
     "votes": 972,
     "clickcount": 2100,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 39.294076,
-    "longitude": 35.2316631
+    "type": "radio"
   },
   {
     "stationuuid": "9605739a-0601-11e8-ae97-52543be04c81",
@@ -1733,9 +1577,7 @@
     "votes": 19028,
     "clickcount": 2090,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 51.1638175,
-    "longitude": 10.4478313
+    "type": "radio"
   },
   {
     "stationuuid": "00dc2e9a-578c-430b-bdc2-244b71444dfc",
@@ -1755,9 +1597,7 @@
     "votes": 661,
     "clickcount": 2090,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 50.6402809,
-    "longitude": 4.6667145
+    "type": "radio"
   },
   {
     "stationuuid": "a90bf48e-c689-4394-a22b-a4980689cedf",
@@ -1777,9 +1617,7 @@
     "votes": 891,
     "clickcount": 2080,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 14.1483443,
-    "longitude": 121.3119391
+    "type": "radio"
   },
   {
     "stationuuid": "960b77af-0601-11e8-ae97-52543be04c81",
@@ -1799,9 +1637,7 @@
     "votes": 10575,
     "clickcount": 2042,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 51.1638175,
-    "longitude": 10.4478313
+    "type": "radio"
   },
   {
     "stationuuid": "2678a502-9a27-4774-a549-e00091878051",
@@ -1821,9 +1657,7 @@
     "votes": 5894,
     "clickcount": 2030,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 55.7497417,
-    "longitude": 37.6022613
+    "type": "radio"
   },
   {
     "stationuuid": "960de706-0601-11e8-ae97-52543be04c81",
@@ -1843,9 +1677,7 @@
     "votes": 47921,
     "clickcount": 2007,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 64.6863136,
-    "longitude": 97.7453061
+    "type": "radio"
   },
   {
     "stationuuid": "960bf492-0601-11e8-ae97-52543be04c81",
@@ -1865,9 +1697,7 @@
     "votes": 49938,
     "clickcount": 1998,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 46.603354,
-    "longitude": 1.8883335
+    "type": "radio"
   },
   {
     "stationuuid": "3606ef8c-cd58-4440-8c47-dbf1e0cacdac",
@@ -1887,9 +1717,7 @@
     "votes": 900,
     "clickcount": 1968,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 52.4577754,
-    "longitude": -1.8692099
+    "type": "radio"
   },
   {
     "stationuuid": "9639c07d-0601-11e8-ae97-52543be04c81",
@@ -1909,9 +1737,7 @@
     "votes": 3864,
     "clickcount": 1963,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 51.1638175,
-    "longitude": 10.4478313
+    "type": "radio"
   },
   {
     "stationuuid": "7b03996e-6ea0-4db5-8168-ddd1463faec2",
@@ -1931,9 +1757,7 @@
     "votes": 3026,
     "clickcount": 1933,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": -38.8082927,
-    "longitude": -70.9347779
+    "type": "radio"
   },
   {
     "stationuuid": "960ac54b-0601-11e8-ae97-52543be04c81",
@@ -1948,14 +1772,12 @@
     "tags": "classical,relax",
     "codec": "MP3",
     "bitrate": 128,
-    "geo_lat": 49.3829708,
-    "geo_long": -95.1533219,
+    "geo_lat": 29.6264964,
+    "geo_long": -82.3645914,
     "votes": 47899,
     "clickcount": 1931,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 29.6264964,
-    "longitude": -82.3645914
+    "type": "radio"
   },
   {
     "stationuuid": "96201b3d-0601-11e8-ae97-52543be04c81",
@@ -1975,9 +1797,7 @@
     "votes": 25372,
     "clickcount": 1929,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 39.294076,
-    "longitude": 35.2316631
+    "type": "radio"
   },
   {
     "stationuuid": "96102c22-0601-11e8-ae97-52543be04c81",
@@ -1997,9 +1817,7 @@
     "votes": 53228,
     "clickcount": 1927,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 46.603354,
-    "longitude": 1.8883335
+    "type": "radio"
   },
   {
     "stationuuid": "a4ffabec-a162-4320-8cf2-049b8055b17a",
@@ -2019,9 +1837,7 @@
     "votes": 10386,
     "clickcount": 1924,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 22.3511148,
-    "longitude": 78.6677428
+    "type": "radio"
   },
   {
     "stationuuid": "96185693-0601-11e8-ae97-52543be04c81",
@@ -2041,9 +1857,7 @@
     "votes": 36304,
     "clickcount": 1920,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 42.6384261,
-    "longitude": 12.674297
+    "type": "radio"
   },
   {
     "stationuuid": "fdbdc2b0-c184-437b-8643-9a5bfa45c253",
@@ -2063,9 +1877,7 @@
     "votes": 1119,
     "clickcount": 1919,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 52.4577754,
-    "longitude": -1.8692099
+    "type": "radio"
   },
   {
     "stationuuid": "2104e3a4-cd98-41f0-b7aa-1354c8ebfc98",
@@ -2085,9 +1897,7 @@
     "votes": 17116,
     "clickcount": 1917,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 26.2540493,
-    "longitude": 29.2675469
+    "type": "radio"
   },
   {
     "stationuuid": "f3dfbec0-8ddb-457c-94cd-368631337c0f",
@@ -2107,9 +1917,7 @@
     "votes": 14565,
     "clickcount": 1913,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 39.294076,
-    "longitude": 35.2316631
+    "type": "radio"
   },
   {
     "stationuuid": "7fb05617-62f2-4c5b-8cfb-86ace94905d2",
@@ -2129,9 +1937,7 @@
     "votes": 979,
     "clickcount": 1901,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 14.1483443,
-    "longitude": 121.3119391
+    "type": "radio"
   },
   {
     "stationuuid": "1fbda80a-41a7-11ea-a95e-52543be04c81",
@@ -2151,9 +1957,7 @@
     "votes": 43764,
     "clickcount": 1892,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 64.6863136,
-    "longitude": 97.7453061
+    "type": "radio"
   },
   {
     "stationuuid": "a853f228-0e27-4461-8657-5b10f2fd79d7",
@@ -2173,9 +1977,7 @@
     "votes": 16590,
     "clickcount": 1885,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 53.4250605,
-    "longitude": 27.6971358
+    "type": "radio"
   },
   {
     "stationuuid": "d69e38f7-f565-4217-b9a8-0075c5e32340",
@@ -2195,9 +1997,7 @@
     "votes": 8882,
     "clickcount": 1880,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 46.603354,
-    "longitude": 1.8883335
+    "type": "radio"
   },
   {
     "stationuuid": "216ee092-939d-43b6-8562-c646f73ad89f",
@@ -2217,9 +2017,7 @@
     "votes": 7625,
     "clickcount": 1876,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 42.6384261,
-    "longitude": 12.674297
+    "type": "radio"
   },
   {
     "stationuuid": "717e3749-b9e8-4497-bd6a-61ccec935922",
@@ -2239,9 +2037,7 @@
     "votes": 686,
     "clickcount": 1871,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 51.1638175,
-    "longitude": 10.4478313
+    "type": "radio"
   },
   {
     "stationuuid": "33178054-56cd-449c-8cf7-412cc7be936a",
@@ -2249,7 +2045,7 @@
     "url": "https://tunein.cdnstream1.com/2868_96.mp3",
     "homepage": "https://www.cnn.com/",
     "favicon": "https://www.cnn.com/media/sites/cnn/favicon.ico",
-    "country": "The United States Of America",
+    "country": "USA",
     "countrycode": "US",
     "state": "",
     "language": "english",
@@ -2262,8 +2058,7 @@
     "clickcount": 1864,
     "lastcheckok": 1,
     "type": "radio",
-    "latitude": 36.1337324,
-    "longitude": -80.2782636
+    "city": "Atlanta"
   },
   {
     "stationuuid": "2f1d6057-52bb-4a33-9b4c-be44a800d832",
@@ -2283,9 +2078,7 @@
     "votes": 8409,
     "clickcount": 1855,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 85,
-    "longitude": -60
+    "type": "radio"
   },
   {
     "stationuuid": "b81c57c3-eb05-47ac-a0ea-eb01a6960cc4",
@@ -2305,9 +2098,7 @@
     "votes": 26293,
     "clickcount": 1851,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 39.3260685,
-    "longitude": -4.8379791
+    "type": "radio"
   },
   {
     "stationuuid": "87906f1e-5f82-4b86-9865-69e8eab8a69a",
@@ -2327,9 +2118,7 @@
     "votes": 1351,
     "clickcount": 1834,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 51.1638175,
-    "longitude": 10.4478313
+    "type": "radio"
   },
   {
     "stationuuid": "961dbb40-0601-11e8-ae97-52543be04c81",
@@ -2344,14 +2133,12 @@
     "tags": "80s,90s,hits,today",
     "codec": "MP3",
     "bitrate": 128,
-    "geo_lat": 36.1337324,
-    "geo_long": -80.2782636,
+    "geo_lat": 38.8888884,
+    "geo_long": -77.0405701,
     "votes": 37716,
     "clickcount": 1819,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 38.8888884,
-    "longitude": -77.0405701
+    "type": "radio"
   },
   {
     "stationuuid": "5dcbb03d-423a-4f97-8af5-b95981094c69",
@@ -2371,9 +2158,7 @@
     "votes": 7906,
     "clickcount": 1815,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": -10.3333333,
-    "longitude": -53.2
+    "type": "radio"
   },
   {
     "stationuuid": "d25cc615-787f-4deb-b6f3-13b253e32433",
@@ -2393,9 +2178,7 @@
     "votes": 6653,
     "clickcount": 1809,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 22.3511148,
-    "longitude": 78.6677428
+    "type": "radio"
   },
   {
     "stationuuid": "e9c34912-885d-4c5b-accd-6c1de459562f",
@@ -2415,9 +2198,7 @@
     "votes": 8405,
     "clickcount": 1801,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 1.5333554,
-    "longitude": 32.2166578
+    "type": "radio"
   },
   {
     "stationuuid": "809098b9-2320-4143-9049-b1fe6f285664",
@@ -2425,21 +2206,20 @@
     "url": "http://radio.talksport.com/stream",
     "homepage": "https://talksport.com/",
     "favicon": "http://i.imgur.com/uy75Hwk.jpg",
-    "country": "The United Kingdom Of Great Britain And Northern Ireland",
+    "country": "UK",
     "countrycode": "GB",
     "state": "",
     "language": "english",
     "tags": "sport",
     "codec": "MP3",
     "bitrate": 64,
-    "geo_lat": 51.4893335,
-    "geo_long": -0.1440551,
+    "geo_lat": 51.5074456,
+    "geo_long": -0.1277653,
     "votes": 1072,
     "clickcount": 1792,
     "lastcheckok": 1,
     "type": "radio",
-    "latitude": 45,
-    "longitude": -50
+    "city": "London"
   },
   {
     "stationuuid": "d227990c-2385-4419-8159-1c73a33a58dd",
@@ -2459,9 +2239,7 @@
     "votes": 6401,
     "clickcount": 1789,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 52.2434979,
-    "longitude": 5.6343227
+    "type": "radio"
   },
   {
     "stationuuid": "9614225b-0601-11e8-ae97-52543be04c81",
@@ -2481,9 +2259,7 @@
     "votes": 5331,
     "clickcount": 1787,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": -28.8166236,
-    "longitude": 24.991639
+    "type": "radio"
   },
   {
     "stationuuid": "dfcef843-6bf9-40f6-b3fe-2b224df86e48",
@@ -2503,9 +2279,7 @@
     "votes": 13064,
     "clickcount": 1784,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 46.603354,
-    "longitude": 1.8883335
+    "type": "radio"
   },
   {
     "stationuuid": "4285a122-9c78-417e-879e-5440c0482c56",
@@ -2525,9 +2299,7 @@
     "votes": 423,
     "clickcount": 1784,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": -34.9964963,
-    "longitude": -64.9672817
+    "type": "radio"
   },
   {
     "stationuuid": "431eb0c9-c84c-11e8-a54a-52543be04c81",
@@ -2547,9 +2319,7 @@
     "votes": 7353,
     "clickcount": 1784,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 35.000074,
-    "longitude": 104.999927
+    "type": "radio"
   },
   {
     "stationuuid": "1e13ed4e-daa9-4728-8550-e08d89c1c8e7",
@@ -2569,9 +2339,7 @@
     "votes": 907,
     "clickcount": 1782,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 47.59397,
-    "longitude": 14.12456
+    "type": "radio"
   },
   {
     "stationuuid": "1daf83f3-6b68-11ea-b1cf-52543be04c81",
@@ -2591,9 +2359,7 @@
     "votes": 48346,
     "clickcount": 1761,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 80,
-    "longitude": -50
+    "type": "radio"
   },
   {
     "stationuuid": "01b61e49-18bd-486d-b0e1-cb51cbaf9a6d",
@@ -2613,9 +2379,7 @@
     "votes": 40674,
     "clickcount": 1761,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 46.603354,
-    "longitude": 1.8883335
+    "type": "radio"
   },
   {
     "stationuuid": "50c3c258-d783-4a1e-89e8-4d8b1f366c56",
@@ -2635,9 +2399,7 @@
     "votes": 5540,
     "clickcount": 1759,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 32.6475314,
-    "longitude": 54.5643516
+    "type": "radio"
   },
   {
     "stationuuid": "e3d8f94f-156e-11e9-a80b-52543be04c81",
@@ -2657,9 +2419,7 @@
     "votes": 43806,
     "clickcount": 1759,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 20,
-    "longitude": -40
+    "type": "radio"
   },
   {
     "stationuuid": "dba206f9-bf7e-11e9-8502-52543be04c81",
@@ -2667,21 +2427,20 @@
     "url": "http://radio.talkradio.co.uk/stream",
     "homepage": "http://talkradio.co.uk/",
     "favicon": "https://cdn-radiotime-logos.tunein.com/s265666q.png",
-    "country": "The United Kingdom Of Great Britain And Northern Ireland",
+    "country": "UK",
     "countrycode": "GB",
     "state": "",
     "language": "",
     "tags": "talk",
     "codec": "MP3",
     "bitrate": 64,
-    "geo_lat": 51.4893335,
-    "geo_long": -0.1440551,
+    "geo_lat": 51.5074456,
+    "geo_long": -0.1277653,
     "votes": 15151,
     "clickcount": 1752,
     "lastcheckok": 1,
     "type": "radio",
-    "latitude": 25,
-    "longitude": -40
+    "city": "London"
   },
   {
     "stationuuid": "db93a00f-9191-46ab-9e87-ec9b373b3eee",
@@ -2701,9 +2460,7 @@
     "votes": 302,
     "clickcount": 1739,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 52.2434979,
-    "longitude": 5.6343227
+    "type": "radio"
   },
   {
     "stationuuid": "65cd1362-71ab-4829-8a4a-f530caf3a465",
@@ -2723,9 +2480,7 @@
     "votes": 10084,
     "clickcount": 1728,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 52.215933,
-    "longitude": 19.134422
+    "type": "radio"
   },
   {
     "stationuuid": "92556f58-20d3-44ae-8faa-322ce5f256c0",
@@ -2745,9 +2500,7 @@
     "votes": 2245,
     "clickcount": 1725,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 51.1638175,
-    "longitude": 10.4478313
+    "type": "radio"
   },
   {
     "stationuuid": "9614aa8d-0601-11e8-ae97-52543be04c81",
@@ -2755,7 +2508,7 @@
     "url": "http://icecast.vgtrk.cdnvideo.ru/mayakfm_mp3_192kbps",
     "homepage": "http://www.radiomayak.ru/",
     "favicon": "",
-    "country": "The Russian Federation",
+    "country": "Russia",
     "countrycode": "RU",
     "state": "",
     "language": "russian",
@@ -2768,8 +2521,7 @@
     "clickcount": 1721,
     "lastcheckok": 1,
     "type": "radio",
-    "latitude": 45,
-    "longitude": -40
+    "city": "Moscow"
   },
   {
     "stationuuid": "0a364b59-56b6-11e9-aa33-52543be04c81",
@@ -2777,7 +2529,7 @@
     "url": "http://dorognoe.hostingradio.ru:8000/radio",
     "homepage": "https://dorognoe.ru/?region=piter",
     "favicon": "https://dorognoe.ru/assets/default/i/fav_114x114.png",
-    "country": "The Russian Federation",
+    "country": "Russia",
     "countrycode": "RU",
     "state": "Saint-Petersburg",
     "language": "russian",
@@ -2790,8 +2542,7 @@
     "clickcount": 1720,
     "lastcheckok": 1,
     "type": "radio",
-    "latitude": 50,
-    "longitude": -40
+    "city": "Moscow"
   },
   {
     "stationuuid": "dd98c499-a0c4-4019-a35e-99caa6940407",
@@ -2811,9 +2562,7 @@
     "votes": 1997,
     "clickcount": 1716,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 51.1638175,
-    "longitude": 10.4478313
+    "type": "radio"
   },
   {
     "stationuuid": "3a386176-7b44-46eb-9461-75fc96121c99",
@@ -2821,7 +2570,7 @@
     "url": "https://kpradio.hostingradio.ru:8000/64",
     "homepage": "https://radiokp.ru/",
     "favicon": "https://radiokp.ru/modules/custom/dna_kpradio/modules/kp_favicon/img/favicon-194x194.png?v=1.1",
-    "country": "The Russian Federation",
+    "country": "Russia",
     "countrycode": "RU",
     "state": "Москва",
     "language": "russian",
@@ -2834,8 +2583,7 @@
     "clickcount": 1713,
     "lastcheckok": 1,
     "type": "radio",
-    "latitude": 60,
-    "longitude": -40
+    "city": "Moscow"
   },
   {
     "stationuuid": "31074f8a-e6f4-11e9-a96c-52543be04c81",
@@ -2855,9 +2603,7 @@
     "votes": 49651,
     "clickcount": 1694,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 46.603354,
-    "longitude": 1.8883335
+    "type": "radio"
   },
   {
     "stationuuid": "b20de429-e1b3-4624-a1ac-12e2bf0cadb0",
@@ -2877,9 +2623,7 @@
     "votes": 479,
     "clickcount": 1690,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 52.2434979,
-    "longitude": 5.6343227
+    "type": "radio"
   },
   {
     "stationuuid": "5a299b9c-71ec-4736-b1d2-57a64793ed9e",
@@ -2899,9 +2643,7 @@
     "votes": 32796,
     "clickcount": 1690,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 36.1337324,
-    "longitude": -80.2782636
+    "type": "radio"
   },
   {
     "stationuuid": "9d2b7b0b-f0cf-4c32-a1ce-bc6e964a7c1a",
@@ -2921,9 +2663,7 @@
     "votes": 12214,
     "clickcount": 1678,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 49.7439047,
-    "longitude": 15.3381061
+    "type": "radio"
   },
   {
     "stationuuid": "d608bb74-0740-47e3-a1e2-c11edfeec91f",
@@ -2943,9 +2683,7 @@
     "votes": 1032,
     "clickcount": 1663,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 51.1638175,
-    "longitude": 10.4478313
+    "type": "radio"
   },
   {
     "stationuuid": "6b36ba4f-6d29-4272-b3c0-9aeeb64e61ec",
@@ -2965,9 +2703,7 @@
     "votes": 9986,
     "clickcount": 1660,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 22.3511148,
-    "longitude": 78.6677428
+    "type": "radio"
   },
   {
     "stationuuid": "960cca40-0601-11e8-ae97-52543be04c81",
@@ -2987,9 +2723,7 @@
     "votes": 28712,
     "clickcount": 1658,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 51.1638175,
-    "longitude": 10.4478313
+    "type": "radio"
   },
   {
     "stationuuid": "a072ec3e-7bb0-4dbc-9f2d-e854733501ee",
@@ -3009,9 +2743,7 @@
     "votes": 13940,
     "clickcount": 1646,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 15.9266657,
-    "longitude": 107.9650855
+    "type": "radio"
   },
   {
     "stationuuid": "9608eb3e-0601-11e8-ae97-52543be04c81",
@@ -3031,9 +2763,7 @@
     "votes": 20461,
     "clickcount": 1637,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 42.6384261,
-    "longitude": 12.674297
+    "type": "radio"
   },
   {
     "stationuuid": "9619eb8a-0601-11e8-ae97-52543be04c81",
@@ -3053,9 +2783,7 @@
     "votes": 14477,
     "clickcount": 1633,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 42.6384261,
-    "longitude": 12.674297
+    "type": "radio"
   },
   {
     "stationuuid": "0c7e5ad0-b89b-466c-867e-a87866eb9a09",
@@ -3075,9 +2803,7 @@
     "votes": 5895,
     "clickcount": 1627,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 35.000074,
-    "longitude": 104.999927
+    "type": "radio"
   },
   {
     "stationuuid": "b3c3ac25-ea2c-4865-8444-7ba9a71960f8",
@@ -3085,7 +2811,7 @@
     "url": "https://radiorecord.hostingradio.ru/rus96.aacp",
     "homepage": "https://www.radiorecord.ru/station/rus",
     "favicon": "",
-    "country": "The Russian Federation",
+    "country": "Russia",
     "countrycode": "RU",
     "state": "",
     "language": "",
@@ -3098,8 +2824,7 @@
     "clickcount": 1625,
     "lastcheckok": 1,
     "type": "radio",
-    "latitude": 45,
-    "longitude": -30
+    "city": "Saint Petersburg"
   },
   {
     "stationuuid": "964da270-0601-11e8-ae97-52543be04c81",
@@ -3107,7 +2832,7 @@
     "url": "http://listen.rusongs.ru/ru-mp3-128",
     "homepage": "http://rusongs.ru/",
     "favicon": "",
-    "country": "The Russian Federation",
+    "country": "Russia",
     "countrycode": "RU",
     "state": "",
     "language": "russian",
@@ -3120,8 +2845,7 @@
     "clickcount": 1622,
     "lastcheckok": 1,
     "type": "radio",
-    "latitude": 50,
-    "longitude": -30
+    "city": "Moscow"
   },
   {
     "stationuuid": "960e96f3-0601-11e8-ae97-52543be04c81",
@@ -3141,9 +2865,7 @@
     "votes": 17081,
     "clickcount": 1612,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 51.1638175,
-    "longitude": 10.4478313
+    "type": "radio"
   },
   {
     "stationuuid": "fb1fd397-78fd-11ea-8a3b-52543be04c81",
@@ -3163,9 +2885,7 @@
     "votes": 9268,
     "clickcount": 1606,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 39.294076,
-    "longitude": 35.2316631
+    "type": "radio"
   },
   {
     "stationuuid": "85c799b3-d91f-4f60-b91a-723e4a04acf5",
@@ -3185,9 +2905,7 @@
     "votes": 21011,
     "clickcount": 1602,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 51.1638175,
-    "longitude": 10.4478313
+    "type": "radio"
   },
   {
     "stationuuid": "9e3b0f8e-95d3-11e9-a605-52543be04c81",
@@ -3207,9 +2925,7 @@
     "votes": 4171,
     "clickcount": 1597,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 51.1638175,
-    "longitude": 10.4478313
+    "type": "radio"
   },
   {
     "stationuuid": "961ac56b-0601-11e8-ae97-52543be04c81",
@@ -3229,9 +2945,7 @@
     "votes": 23179,
     "clickcount": 1582,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 46.7985624,
-    "longitude": 8.2319736
+    "type": "radio"
   },
   {
     "stationuuid": "44ee797f-b7c4-4f94-8853-ce9a9c8731ed",
@@ -3251,9 +2965,7 @@
     "votes": 1851,
     "clickcount": 1570,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 51.1638175,
-    "longitude": 10.4478313
+    "type": "radio"
   },
   {
     "stationuuid": "10f16cf6-bc45-4b67-8f17-9758f249a61a",
@@ -3273,9 +2985,7 @@
     "votes": 2275,
     "clickcount": 1561,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 51.1638175,
-    "longitude": 10.4478313
+    "type": "radio"
   },
   {
     "stationuuid": "961e5274-0601-11e8-ae97-52543be04c81",
@@ -3295,9 +3005,7 @@
     "votes": 47896,
     "clickcount": 1554,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 90,
-    "longitude": -30
+    "type": "radio"
   },
   {
     "stationuuid": "4e285d46-4491-4df0-a6d8-974b8b9a49f8",
@@ -3317,9 +3025,7 @@
     "votes": 657,
     "clickcount": 1545,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 20,
-    "longitude": -20
+    "type": "radio"
   },
   {
     "stationuuid": "960cc332-0601-11e8-ae97-52543be04c81",
@@ -3339,9 +3045,7 @@
     "votes": 22785,
     "clickcount": 1538,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 36.1337324,
-    "longitude": -80.2782636
+    "type": "radio"
   },
   {
     "stationuuid": "9608c0e3-0601-11e8-ae97-52543be04c81",
@@ -3361,9 +3065,7 @@
     "votes": 5622,
     "clickcount": 1534,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 51.1638175,
-    "longitude": 10.4478313
+    "type": "radio"
   },
   {
     "stationuuid": "df369586-40fc-11e9-aa55-52543be04c81",
@@ -3383,9 +3085,7 @@
     "votes": 13985,
     "clickcount": 1531,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 39.294076,
-    "longitude": 35.2316631
+    "type": "radio"
   },
   {
     "stationuuid": "9605ec6a-0601-11e8-ae97-52543be04c81",
@@ -3405,9 +3105,7 @@
     "votes": 5938,
     "clickcount": 1514,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 51.1638175,
-    "longitude": 10.4478313
+    "type": "radio"
   },
   {
     "stationuuid": "36e39a32-ff61-440a-8fef-31b543fab883",
@@ -3427,9 +3125,7 @@
     "votes": 4328,
     "clickcount": 1513,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 32.6475314,
-    "longitude": 54.5643516
+    "type": "radio"
   },
   {
     "stationuuid": "529b71b3-ac05-426c-bd8c-6ae981713900",
@@ -3449,9 +3145,7 @@
     "votes": 303,
     "clickcount": 1484,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 50.6402809,
-    "longitude": 4.6667145
+    "type": "radio"
   },
   {
     "stationuuid": "bbd2fa5a-0b6c-4833-81b4-ca69acb8f264",
@@ -3471,9 +3165,7 @@
     "votes": 288,
     "clickcount": 1476,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 36.1337324,
-    "longitude": -80.2782636
+    "type": "radio"
   },
   {
     "stationuuid": "1c6dcd6f-88c6-4fd4-8191-078435168e85",
@@ -3481,21 +3173,20 @@
     "url": "http://as-hls-ww-live.akamaized.net/pool_81827798/live/ww/bbc_6music/bbc_6music.isml/bbc_6music-audio%3d320000.norewind.m3u8",
     "homepage": "https://www.bbc.co.uk/sounds/play/live:bbc_6music",
     "favicon": "https://de8as167a043l.cloudfront.net/styles/images/logosplus/120x120xBBCR6.png",
-    "country": "The United Kingdom Of Great Britain And Northern Ireland",
+    "country": "UK",
     "countrycode": "GB",
     "state": "",
     "language": "english",
     "tags": "alternative,blues,dance,eclectic,electronic,experimental,funk,grime,hip hop,house,indie,jazz,metal,pop,punk,r&b,reggae,rock,ska,soul,techno,world",
     "codec": "UNKNOWN",
     "bitrate": 0,
-    "geo_lat": 51.4893335,
-    "geo_long": -0.1440551,
+    "geo_lat": 51.5074456,
+    "geo_long": -0.1277653,
     "votes": 1386,
     "clickcount": 1464,
     "lastcheckok": 1,
     "type": "radio",
-    "latitude": 60,
-    "longitude": -20
+    "city": "London"
   },
   {
     "stationuuid": "447a1a5f-aee6-4b21-b85f-10ceb1896ad3",
@@ -3515,9 +3206,7 @@
     "votes": 1725,
     "clickcount": 1443,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": -10.3333333,
-    "longitude": -53.2
+    "type": "radio"
   },
   {
     "stationuuid": "9637a1b2-0601-11e8-ae97-52543be04c81",
@@ -3537,9 +3226,7 @@
     "votes": 21805,
     "clickcount": 1439,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 53.5140296,
-    "longitude": 10.2480924
+    "type": "radio"
   },
   {
     "stationuuid": "bf487b2b-503c-42c3-b088-9b5d679fdf29",
@@ -3559,9 +3246,7 @@
     "votes": 4052,
     "clickcount": 1434,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 52.215933,
-    "longitude": 19.134422
+    "type": "radio"
   },
   {
     "stationuuid": "e25470de-0bea-43c1-8c84-475c6c500c1a",
@@ -3581,9 +3266,7 @@
     "votes": 8149,
     "clickcount": 1431,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 26.2540493,
-    "longitude": 29.2675469
+    "type": "radio"
   },
   {
     "stationuuid": "961ffb71-0601-11e8-ae97-52543be04c81",
@@ -3603,9 +3286,7 @@
     "votes": 4042,
     "clickcount": 1415,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 85,
-    "longitude": -20
+    "type": "radio"
   },
   {
     "stationuuid": "d81fd5d3-4c24-4768-88b3-57954e77c0e7",
@@ -3625,9 +3306,7 @@
     "votes": 1091,
     "clickcount": 1405,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 52.215933,
-    "longitude": 19.134422
+    "type": "radio"
   },
   {
     "stationuuid": "21ef0997-adba-46c7-a2e1-03e3130bd5ad",
@@ -3647,9 +3326,7 @@
     "votes": 5372,
     "clickcount": 1405,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 46.603354,
-    "longitude": 1.8883335
+    "type": "radio"
   },
   {
     "stationuuid": "7f753b43-eb65-4638-bcea-8dbaaf620b0d",
@@ -3669,9 +3346,7 @@
     "votes": 12795,
     "clickcount": 1401,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 1.5333554,
-    "longitude": 32.2166578
+    "type": "radio"
   },
   {
     "stationuuid": "961f1da4-0601-11e8-ae97-52543be04c81",
@@ -3691,9 +3366,7 @@
     "votes": 5065,
     "clickcount": 1399,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 46.7985624,
-    "longitude": 8.2319736
+    "type": "radio"
   },
   {
     "stationuuid": "2dffb353-5341-4438-b67b-83de8c3efbab",
@@ -3713,9 +3386,7 @@
     "votes": 3803,
     "clickcount": 1386,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 46.603354,
-    "longitude": 1.8883335
+    "type": "radio"
   },
   {
     "stationuuid": "675bd925-8b13-43fe-a1b9-43bb0f90fbbd",
@@ -3735,9 +3406,7 @@
     "votes": 1668,
     "clickcount": 1384,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 42.6384261,
-    "longitude": 12.674297
+    "type": "radio"
   },
   {
     "stationuuid": "98b22cd2-0ec8-4bb1-a5f6-f168de7548b5",
@@ -3757,9 +3426,7 @@
     "votes": 5751,
     "clickcount": 1369,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 47.1817585,
-    "longitude": 19.5060937
+    "type": "radio"
   },
   {
     "stationuuid": "961fb4b2-0601-11e8-ae97-52543be04c81",
@@ -3779,9 +3446,7 @@
     "votes": 9579,
     "clickcount": 1368,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 46.7985624,
-    "longitude": 8.2319736
+    "type": "radio"
   },
   {
     "stationuuid": "ec55577f-cff5-4b8b-aeaa-6438c2dfc446",
@@ -3801,9 +3466,7 @@
     "votes": 2057,
     "clickcount": 1367,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 4.5693754,
-    "longitude": 102.2656823
+    "type": "radio"
   },
   {
     "stationuuid": "97730dcf-857f-4b0a-9f33-c18af303c14b",
@@ -3823,9 +3486,7 @@
     "votes": 1559,
     "clickcount": 1364,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 51.1638175,
-    "longitude": 10.4478313
+    "type": "radio"
   },
   {
     "stationuuid": "71623064-347c-4e85-8136-148115d350f2",
@@ -3845,9 +3506,7 @@
     "votes": 2101,
     "clickcount": 1363,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 14.1483443,
-    "longitude": 121.3119391
+    "type": "radio"
   },
   {
     "stationuuid": "379df4ba-0483-481d-9a8c-87a6f59b9be3",
@@ -3867,9 +3526,7 @@
     "votes": 5432,
     "clickcount": 1362,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 14.1483443,
-    "longitude": 121.3119391
+    "type": "radio"
   },
   {
     "stationuuid": "9ebf344d-3885-49fa-8b1e-29f5367fda0f",
@@ -3889,9 +3546,7 @@
     "votes": 802,
     "clickcount": 1359,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 53.4250605,
-    "longitude": 27.6971358
+    "type": "radio"
   },
   {
     "stationuuid": "cae35448-1285-4f12-b3e0-2f4fdde00002",
@@ -3911,9 +3566,7 @@
     "votes": 961,
     "clickcount": 1356,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 80,
-    "longitude": -10
+    "type": "radio"
   },
   {
     "stationuuid": "49970d3a-0a50-4655-8dfb-9065b279d662",
@@ -3933,9 +3586,7 @@
     "votes": 222,
     "clickcount": 1356,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": -28.8166236,
-    "longitude": 24.991639
+    "type": "radio"
   },
   {
     "stationuuid": "9346c66b-f42a-4a06-865d-e96dc44b1aa3",
@@ -3955,9 +3606,7 @@
     "votes": 2069,
     "clickcount": 1351,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 26.2540493,
-    "longitude": 29.2675469
+    "type": "radio"
   },
   {
     "stationuuid": "3fd18c3f-8157-11e9-aa30-52543be04c81",
@@ -3977,9 +3626,7 @@
     "votes": 6968,
     "clickcount": 1351,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 39.3260685,
-    "longitude": -4.8379791
+    "type": "radio"
   },
   {
     "stationuuid": "63bb901a-e09a-478b-9c5e-b7f6a1f9efc4",
@@ -3999,9 +3646,7 @@
     "votes": 261,
     "clickcount": 1344,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 47.59397,
-    "longitude": 14.12456
+    "type": "radio"
   },
   {
     "stationuuid": "d30c6196-61cd-4fa4-b597-6fd6bff3da91",
@@ -4021,9 +3666,7 @@
     "votes": 4758,
     "clickcount": 1341,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 14.1483443,
-    "longitude": 121.3119391
+    "type": "radio"
   },
   {
     "stationuuid": "60ceaabd-4efd-4f47-b961-0dab6f475731",
@@ -4043,9 +3686,7 @@
     "votes": 31665,
     "clickcount": 1339,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 46.603354,
-    "longitude": 1.8883335
+    "type": "radio"
   },
   {
     "stationuuid": "f56fc0e0-8d6e-43df-9253-bfa03cb9a067",
@@ -4065,9 +3706,7 @@
     "votes": 717,
     "clickcount": 1338,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 52.215933,
-    "longitude": 19.134422
+    "type": "radio"
   },
   {
     "stationuuid": "ac374cbd-6ea3-417e-b8d1-967c77bec430",
@@ -4087,9 +3726,7 @@
     "votes": 1352,
     "clickcount": 1336,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 45,
-    "longitude": 0
+    "type": "radio"
   },
   {
     "stationuuid": "d1b0b82d-aa27-49e5-a98e-716ceff7e2f7",
@@ -4109,9 +3746,7 @@
     "votes": 8884,
     "clickcount": 1331,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 50,
-    "longitude": 0
+    "type": "radio"
   },
   {
     "stationuuid": "b8601593-152a-429d-9cb2-5065cf7c0185",
@@ -4131,9 +3766,7 @@
     "votes": 2089,
     "clickcount": 1324,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 39.3260685,
-    "longitude": -4.8379791
+    "type": "radio"
   },
   {
     "stationuuid": "f437a938-2f30-4109-8f52-cbb599e11b03",
@@ -4154,8 +3787,7 @@
     "clickcount": 1308,
     "lastcheckok": 1,
     "type": "radio",
-    "latitude": 28.3347722,
-    "longitude": -10.3713379
+    "city": "Casablanca"
   },
   {
     "stationuuid": "5681d06a-f5af-11e9-bbf2-52543be04c81",
@@ -4175,9 +3807,7 @@
     "votes": 11655,
     "clickcount": 1306,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 36.1337324,
-    "longitude": -80.2782636
+    "type": "radio"
   },
   {
     "stationuuid": "3bdf2126-b792-46f6-b0bd-9c991411e373",
@@ -4197,9 +3827,7 @@
     "votes": 697,
     "clickcount": 1305,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": -28.8166236,
-    "longitude": 24.991639
+    "type": "radio"
   },
   {
     "stationuuid": "6be8c695-6943-4776-80f0-15a7d49812be",
@@ -4219,9 +3847,7 @@
     "votes": 4312,
     "clickcount": 1296,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 32.6475314,
-    "longitude": 54.5643516
+    "type": "radio"
   },
   {
     "stationuuid": "cdd58252-09b9-4c89-b688-243cf107ad29",
@@ -4241,9 +3867,7 @@
     "votes": 2095,
     "clickcount": 1294,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": -2.4833826,
-    "longitude": 117.8902853
+    "type": "radio"
   },
   {
     "stationuuid": "9611ecb1-0601-11e8-ae97-52543be04c81",
@@ -4263,9 +3887,7 @@
     "votes": 13020,
     "clickcount": 1293,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 39.3260685,
-    "longitude": -4.8379791
+    "type": "radio"
   },
   {
     "stationuuid": "ea391ded-00f0-47e0-841c-d92663e11854",
@@ -4285,9 +3907,7 @@
     "votes": 1920,
     "clickcount": 1287,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 90,
-    "longitude": 0
+    "type": "radio"
   },
   {
     "stationuuid": "ae209b3a-d20a-48f2-b303-22d68e385bf4",
@@ -4307,9 +3927,7 @@
     "votes": 1622,
     "clickcount": 1279,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 51.1638175,
-    "longitude": 10.4478313
+    "type": "radio"
   },
   {
     "stationuuid": "7ada8a81-5ae1-418c-8f18-51d2f38d86a4",
@@ -4329,9 +3947,7 @@
     "votes": 6511,
     "clickcount": 1264,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": -10.3333333,
-    "longitude": -53.2
+    "type": "radio"
   },
   {
     "stationuuid": "850723b8-24a6-4dca-add8-b0da39db7d39",
@@ -4351,9 +3967,7 @@
     "votes": 3183,
     "clickcount": 1260,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 14.8971921,
-    "longitude": 100.83273
+    "type": "radio"
   },
   {
     "stationuuid": "c4175f89-69da-11ea-b1cf-52543be04c81",
@@ -4373,9 +3987,7 @@
     "votes": 3954,
     "clickcount": 1257,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 35,
-    "longitude": 10
+    "type": "radio"
   },
   {
     "stationuuid": "9610c454-0601-11e8-ae97-52543be04c81",
@@ -4395,9 +4007,7 @@
     "votes": 12570,
     "clickcount": 1241,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 51.1638175,
-    "longitude": 10.4478313
+    "type": "radio"
   },
   {
     "stationuuid": "36a6d57a-4d8a-45e3-aad9-7931c6e43c56",
@@ -4417,9 +4027,7 @@
     "votes": 3438,
     "clickcount": 1240,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 51.1638175,
-    "longitude": 10.4478313
+    "type": "radio"
   },
   {
     "stationuuid": "0b2c57db-885d-46d8-bbee-0651449759f1",
@@ -4427,7 +4035,7 @@
     "url": "https://tunein.cdnstream1.com/3511_96.mp3",
     "homepage": "https://www.msnbc.com/",
     "favicon": "https://nodeassets.nbcnews.com/cdnassets/projects/ramen/favicon/msnbc/all-other-sizes-PNG.ico/favicon-96x96.png",
-    "country": "The United States Of America",
+    "country": "USA",
     "countrycode": "US",
     "state": "",
     "language": "english",
@@ -4440,8 +4048,7 @@
     "clickcount": 1235,
     "lastcheckok": 1,
     "type": "radio",
-    "latitude": 36.1337324,
-    "longitude": -80.2782636
+    "city": "New York"
   },
   {
     "stationuuid": "962a748b-0601-11e8-ae97-52543be04c81",
@@ -4461,9 +4068,7 @@
     "votes": 15977,
     "clickcount": 1227,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 46.7985624,
-    "longitude": 8.2319736
+    "type": "radio"
   },
   {
     "stationuuid": "fc4c247a-7f66-11e9-aa30-52543be04c81",
@@ -4483,9 +4088,7 @@
     "votes": 837,
     "clickcount": 1214,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 60,
-    "longitude": 10
+    "type": "radio"
   },
   {
     "stationuuid": "a1249d7e-eb60-48bf-ba83-ebf3960b9a90",
@@ -4505,9 +4108,7 @@
     "votes": 693,
     "clickcount": 1208,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 51.1638175,
-    "longitude": 10.4478313
+    "type": "radio"
   },
   {
     "stationuuid": "57742af1-79d4-4bc7-ae81-b58146638ae7",
@@ -4527,9 +4128,7 @@
     "votes": 2811,
     "clickcount": 1207,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 22.3511148,
-    "longitude": 78.6677428
+    "type": "radio"
   },
   {
     "stationuuid": "3f6d52c1-9373-4fd2-8bef-5dd476e4e7d2",
@@ -4549,9 +4148,7 @@
     "votes": 1039,
     "clickcount": 1206,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 35.000074,
-    "longitude": 104.999927
+    "type": "radio"
   },
   {
     "stationuuid": "3d9dcff7-8fd2-4eda-9d77-cfe259c62a70",
@@ -4571,9 +4168,7 @@
     "votes": 178,
     "clickcount": 1199,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 52.4043474,
-    "longitude": 13.0392969
+    "type": "radio"
   },
   {
     "stationuuid": "706def0c-7017-4601-8305-db1cdb2e9420",
@@ -4593,9 +4188,7 @@
     "votes": 3493,
     "clickcount": 1196,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 39.294076,
-    "longitude": 35.2316631
+    "type": "radio"
   },
   {
     "stationuuid": "653ec48e-d763-4e0f-965f-6b9c6bf41562",
@@ -4615,9 +4208,7 @@
     "votes": 1135,
     "clickcount": 1195,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 22.3511148,
-    "longitude": 78.6677428
+    "type": "radio"
   },
   {
     "stationuuid": "96163b46-0601-11e8-ae97-52543be04c81",
@@ -4637,9 +4228,7 @@
     "votes": 13688,
     "clickcount": 1191,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 20,
-    "longitude": 20
+    "type": "radio"
   },
   {
     "stationuuid": "1f3700b5-4875-4bdf-986d-1dcaa4e8dfbe",
@@ -4659,9 +4248,7 @@
     "votes": 622,
     "clickcount": 1187,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 51.1638175,
-    "longitude": 10.4478313
+    "type": "radio"
   },
   {
     "stationuuid": "74c09a82-e6f1-4276-8afc-d25ea6d02898",
@@ -4681,9 +4268,7 @@
     "votes": 3656,
     "clickcount": 1187,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 22.3511148,
-    "longitude": 78.6677428
+    "type": "radio"
   },
   {
     "stationuuid": "7ba4c184-fc2b-11e9-bbf2-52543be04c81",
@@ -4691,7 +4276,7 @@
     "url": "http://npr-ice.streamguys1.com/live.mp3",
     "homepage": "https://www.npr.org/2016/04/05/472557877/npr-program-stream",
     "favicon": "https://static-assets.npr.org/static/images/favicon/favicon-96x96.png",
-    "country": "The United States Of America",
+    "country": "USA",
     "countrycode": "US",
     "state": "",
     "language": "english",
@@ -4704,8 +4289,7 @@
     "clickcount": 1181,
     "lastcheckok": 1,
     "type": "radio",
-    "latitude": 36.1337324,
-    "longitude": -80.2782636
+    "city": "Washington D.C."
   },
   {
     "stationuuid": "f0ab0c5c-7125-476c-97a4-2eabc14f5f05",
@@ -4725,9 +4309,7 @@
     "votes": 151,
     "clickcount": 1174,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 52.2434979,
-    "longitude": 5.6343227
+    "type": "radio"
   },
   {
     "stationuuid": "24ed379c-7425-4367-9fbd-bf960eec0c91",
@@ -4747,9 +4329,7 @@
     "votes": 36960,
     "clickcount": 1171,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 28.0000272,
-    "longitude": 2.9999825
+    "type": "radio"
   },
   {
     "stationuuid": "96136fe5-0601-11e8-ae97-52543be04c81",
@@ -4769,9 +4349,7 @@
     "votes": 40938,
     "clickcount": 1170,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 46.603354,
-    "longitude": 1.8883335
+    "type": "radio"
   },
   {
     "stationuuid": "96266006-0601-11e8-ae97-52543be04c81",
@@ -4791,9 +4369,7 @@
     "votes": 18866,
     "clickcount": 1161,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": 55,
-    "longitude": 20
+    "type": "radio"
   },
   {
     "stationuuid": "5f96f5c1-e75a-4129-abd3-d7e08360fa56",
@@ -4813,8 +4389,6 @@
     "votes": 4384,
     "clickcount": 1158,
     "lastcheckok": 1,
-    "type": "radio",
-    "latitude": -2.4833826,
-    "longitude": 117.8902853
+    "type": "radio"
   }
 ]

--- a/src/data/tvStationsWithUrls.json
+++ b/src/data/tvStationsWithUrls.json
@@ -3548,8 +3548,8 @@
     "city": "Canaf54",
     "categories": "General",
     "type": "tv",
-    "geo_lat": 50,
-    "geo_long": -42
+    "geo_lat": 54.7023545,
+    "geo_long": -3.2765753
   },
   {
     "id": "Canal1.co",
@@ -3572,8 +3572,8 @@
     "city": "Canal 1 720p",
     "categories": "General",
     "type": "tv",
-    "geo_lat": 54,
-    "geo_long": -42
+    "geo_lat": 10.2735633,
+    "geo_long": -84.0739102
   },
   {
     "id": "Canal2.sv",
@@ -3644,8 +3644,8 @@
     "city": "Canal 4 720p Geo",
     "categories": "General",
     "type": "tv",
-    "geo_lat": 46,
-    "geo_long": -40
+    "geo_lat": 10.2735633,
+    "geo_long": -84.0739102
   },
   {
     "id": "Canal4Catalunya.es",
@@ -3692,8 +3692,8 @@
     "city": "Canal 6 720p Geo",
     "categories": "General",
     "type": "tv",
-    "geo_lat": 54,
-    "geo_long": -40
+    "geo_lat": 10.2735633,
+    "geo_long": -84.0739102
   },
   {
     "id": "Canal6.sv",
@@ -3740,8 +3740,8 @@
     "city": "Canal 8 720p Not 247",
     "categories": "General",
     "type": "tv",
-    "geo_lat": 42,
-    "geo_long": -38
+    "geo_lat": 10.2735633,
+    "geo_long": -84.0739102
   },
   {
     "id": "Canal8Catacaos.pe",
@@ -3776,8 +3776,8 @@
     "city": "Canal 9 720p Geo",
     "categories": "General",
     "type": "tv",
-    "geo_lat": 48,
-    "geo_long": -38
+    "geo_lat": 10.2735633,
+    "geo_long": -84.0739102
   },
   {
     "id": "BarbeTV.gt",
@@ -3836,8 +3836,8 @@
     "city": "Canal 11 720p Geo",
     "categories": "General",
     "type": "tv",
-    "geo_lat": 58,
-    "geo_long": -38
+    "geo_lat": 10.2735633,
+    "geo_long": -84.0739102
   },
   {
     "id": "Canal11TuTV.sv",
@@ -3884,8 +3884,8 @@
     "city": "Canal 20 720p Not 247",
     "categories": "General",
     "type": "tv",
-    "geo_lat": 46,
-    "geo_long": -36
+    "geo_lat": 15.5855545,
+    "geo_long": -90.345759
   },
   {
     "id": "Canal21Tachira.ve",
@@ -3992,8 +3992,8 @@
     "city": "Canal Catorce 720p",
     "categories": "General",
     "type": "tv",
-    "geo_lat": 44,
-    "geo_long": -34
+    "geo_lat": 19.0974031,
+    "geo_long": -70.3028026
   },
   {
     "id": "CanalDTV.do",
@@ -4064,8 +4064,8 @@
     "city": "Canal Multivision 720p",
     "categories": "General",
     "type": "tv",
-    "geo_lat": 56,
-    "geo_long": -34
+    "geo_lat": 19.0974031,
+    "geo_long": -70.3028026
   },
   {
     "id": "CanalReusTV.es",
@@ -4196,8 +4196,8 @@
     "city": "Canal Zoom Geo",
     "categories": "General",
     "type": "tv",
-    "geo_lat": 58,
-    "geo_long": -32
+    "geo_lat": 50.6402809,
+    "geo_long": 4.6667145
   },
   {
     "id": "Canale2Altamura.it",
@@ -4340,8 +4340,8 @@
     "city": "Caribbean Advantage",
     "categories": "General",
     "type": "tv",
-    "geo_lat": 42,
-    "geo_long": -28
+    "geo_lat": 18.2247706,
+    "geo_long": -66.4858295
   },
   {
     "id": "CaribbeanHot7TV.lc",

--- a/src/data/tvStationsWithUrls.json.bak
+++ b/src/data/tvStationsWithUrls.json.bak
@@ -9,9 +9,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 52.1326,
-    "geo_long": 5.2913,
-    "latitude": 52.1326,
-    "longitude": 5.2913
+    "geo_long": 5.2913
   },
   {
     "id": "1KZNTV.za",
@@ -23,9 +21,7 @@
     "categories": "Entertainment;Family;General",
     "type": "tv",
     "geo_lat": -30.5595,
-    "geo_long": 22.9375,
-    "latitude": -30.5595,
-    "longitude": 22.9375
+    "geo_long": 22.9375
   },
   {
     "id": "1TV.af@SD",
@@ -37,9 +33,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 33.7680065,
-    "geo_long": 66.2385139,
-    "latitude": 33.7680065,
-    "longitude": 66.2385139
+    "geo_long": 66.2385139
   },
   {
     "id": "1TV.ge",
@@ -47,13 +41,11 @@
     "url": "https://tv.cdn.xsg.ge/gpb-1tv/index.m3u8",
     "logo": "https://i.imgur.com/FSkYLPK.png",
     "country": "Georgia",
-    "city": "Tbilisi",
+    "city": "Unknown",
     "categories": "General",
     "type": "tv",
-    "geo_lat": 41.7151,
-    "geo_long": 44.8271,
-    "latitude": 41.7151,
-    "longitude": 44.8271
+    "geo_lat": 32.3293809,
+    "geo_long": -83.1137366
   },
   {
     "id": "1TwenteTV.nl@SD",
@@ -65,9 +57,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 52.2309956,
-    "geo_long": 6.8954277,
-    "latitude": 52.2309956,
-    "longitude": 6.8954277
+    "geo_long": 6.8954277
   },
   {
     "id": "002RadioTV.do",
@@ -79,9 +69,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 11.835831,
-    "geo_long": 51.2785088,
-    "latitude": 11.835831,
-    "longitude": 51.2785088
+    "geo_long": 51.2785088
   },
   {
     "id": "2M.ma@SD",
@@ -93,9 +81,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 58.2287982,
-    "geo_long": 6.5242929,
-    "latitude": 25.029422,
-    "longitude": -77.361956
+    "geo_long": 6.5242929
   },
   {
     "id": "2MMonde.ma@SD",
@@ -107,9 +93,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 0.5390647,
-    "geo_long": 32.1450213,
-    "latitude": 0.5390647,
-    "longitude": 32.1450213
+    "geo_long": 32.1450213
   },
   {
     "id": "2TV.ge",
@@ -117,13 +101,11 @@
     "url": "https://tv.cdn.xsg.ge/gpb-2tv/index.m3u8",
     "logo": "https://i.imgur.com/FJBL6zI.png",
     "country": "Georgia",
-    "city": "Tbilisi",
+    "city": "Unknown",
     "categories": "General",
     "type": "tv",
-    "geo_lat": 41.7151,
-    "geo_long": 44.8271,
-    "latitude": 41.7151,
-    "longitude": 44.8271
+    "geo_lat": 32.3293809,
+    "geo_long": -83.1137366
   },
   {
     "id": "3HD.th",
@@ -135,9 +117,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 14.8971921,
-    "geo_long": 100.83273,
-    "latitude": 26.1668651,
-    "longitude": 78.1778261
+    "geo_long": 100.83273
   },
   {
     "id": "3sat.de",
@@ -149,9 +129,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 51.1657,
-    "geo_long": 10.4515,
-    "latitude": 51.1657,
-    "longitude": 10.4515
+    "geo_long": 10.4515
   },
   {
     "id": "3sat.de@HD",
@@ -163,9 +141,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 51.1657,
-    "geo_long": 10.4515,
-    "latitude": 51.1657,
-    "longitude": 10.4515
+    "geo_long": 10.4515
   },
   {
     "id": "5tv.ar",
@@ -177,9 +153,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -38.4161,
-    "geo_long": -63.6167,
-    "latitude": -38.4161,
-    "longitude": -63.6167
+    "geo_long": -63.6167
   },
   {
     "id": "Channel5.ru",
@@ -191,9 +165,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 61.524,
-    "geo_long": 105.3188,
-    "latitude": 61.524,
-    "longitude": 105.3188
+    "geo_long": 105.3188
   },
   {
     "id": "Canal7TeleValencia.es",
@@ -205,9 +177,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 40.4637,
-    "geo_long": -3.7492,
-    "latitude": 40.4637,
-    "longitude": -3.7492
+    "geo_long": -3.7492
   },
   {
     "id": "7TVSenegal.sn@SD",
@@ -219,9 +189,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 14.4750607,
-    "geo_long": -14.4529612,
-    "latitude": 14.4750607,
-    "longitude": -14.4529612
+    "geo_long": -14.4529612
   },
   {
     "id": "8LaMarinaTV.es",
@@ -233,9 +201,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.3260685,
-    "geo_long": -4.8379791,
-    "latitude": 38.9099812,
-    "longitude": 1.436854
+    "geo_long": -4.8379791
   },
   {
     "id": "8NTV.mx",
@@ -247,9 +213,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 23.6585116,
-    "geo_long": -102.0077097,
-    "latitude": 25.029422,
-    "longitude": -77.361956
+    "geo_long": -102.0077097
   },
   {
     "id": "9laLomaTV.es",
@@ -261,9 +225,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 40.4637,
-    "geo_long": -3.7492,
-    "latitude": 40.4637,
-    "longitude": -3.7492
+    "geo_long": -3.7492
   },
   {
     "id": "12tv.es",
@@ -275,9 +237,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 40.4637,
-    "geo_long": -3.7492,
-    "latitude": 40.4637,
-    "longitude": -3.7492
+    "geo_long": -3.7492
   },
   {
     "id": "12TVParma.it",
@@ -289,9 +249,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 42.6384261,
-    "geo_long": 12.674297,
-    "latitude": 28.0613438,
-    "longitude": 81.610291
+    "geo_long": 12.674297
   },
   {
     "id": "Channel12.ru",
@@ -303,9 +261,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 64.6863136,
-    "geo_long": 97.7453061,
-    "latitude": 64.6863136,
-    "longitude": 97.7453061
+    "geo_long": 97.7453061
   },
   {
     "id": "13MaxTelevision.ar",
@@ -317,9 +273,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -34.9964963,
-    "geo_long": -64.9672817,
-    "latitude": -34.9964963,
-    "longitude": -64.9672817
+    "geo_long": -64.9672817
   },
   {
     "id": "15TV.mx@SD",
@@ -331,9 +285,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 45.0497701,
-    "geo_long": 2.6997176,
-    "latitude": 11.6165284,
-    "longitude": 125.4292222
+    "geo_long": 2.6997176
   },
   {
     "id": "16tvBudapest.hu",
@@ -345,9 +297,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 47.1817585,
-    "geo_long": 19.5060937,
-    "latitude": 47.1817585,
-    "longitude": 19.5060937
+    "geo_long": 19.5060937
   },
   {
     "id": "20MinutesTV.fr",
@@ -359,23 +309,19 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 46.603354,
-    "geo_long": 1.8883335,
-    "latitude": 48.8768086,
-    "longitude": 2.360696
+    "geo_long": 1.8883335
   },
   {
     "id": "KERODT1.us",
     "name": "23 ABC Bakersfield CA (KERO) (720p)",
     "url": "https://content.uplynk.com/channel/ff809e6d9ec34109abfb333f0d4444b5.m3u8",
     "logo": "https://i.imgur.com/CMANZWk.png",
-    "country": "Unknown",
-    "city": "23 ABC Bakersfield CA KERO 720",
+    "country": "USA",
+    "city": "Bakersfield",
     "categories": "General",
     "type": "tv",
     "geo_lat": 35.3738712,
-    "geo_long": -119.019463,
-    "latitude": 35.3733,
-    "longitude": -119.0187
+    "geo_long": -119.019463
   },
   {
     "id": "28kanala.es@SD",
@@ -387,9 +333,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 43.13511,
-    "geo_long": -2.081344,
-    "latitude": 43.13511,
-    "longitude": -2.081344
+    "geo_long": -2.081344
   },
   {
     "id": "101tvAntequera.es",
@@ -401,9 +345,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.3260685,
-    "geo_long": -4.8379791,
-    "latitude": 39.3260685,
-    "longitude": -4.8379791
+    "geo_long": -4.8379791
   },
   {
     "id": "101tvAxarquia.es",
@@ -415,9 +357,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.3260685,
-    "geo_long": -4.8379791,
-    "latitude": 39.3260685,
-    "longitude": -4.8379791
+    "geo_long": -4.8379791
   },
   {
     "id": "101tvRonda.es",
@@ -429,9 +369,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.3260685,
-    "geo_long": -4.8379791,
-    "latitude": 39.3260685,
-    "longitude": -4.8379791
+    "geo_long": -4.8379791
   },
   {
     "id": "101tvSevilla.es",
@@ -443,9 +381,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.3260685,
-    "geo_long": -4.8379791,
-    "latitude": 39.3260685,
-    "longitude": -4.8379791
+    "geo_long": -4.8379791
   },
   {
     "id": "360.ru",
@@ -457,23 +393,19 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 64.6863136,
-    "geo_long": 97.7453061,
-    "latitude": 64.6863136,
-    "longitude": 97.7453061
+    "geo_long": 97.7453061
   },
   {
     "id": "360RFTV.cr",
     "name": "360 RFTV (576p) [Geo-blocked]",
     "url": "https://acceso.radiosportstv.online:3417/live/360rftvcrlive.m3u8",
     "logo": "https://i.imgur.com/EBtgnxR.png",
-    "country": "Unknown",
-    "city": "360 RFTV 576p Geo",
+    "country": "Costa Rica",
+    "city": "Nosara",
     "categories": "General",
     "type": "tv",
     "geo_lat": 9.9799546,
-    "geo_long": -85.6528372,
-    "latitude": 10.2735633,
-    "longitude": -84.0739102
+    "geo_long": -85.6528372
   },
   {
     "id": "A1TV.nl",
@@ -485,9 +417,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 52.2434979,
-    "geo_long": 5.6343227,
-    "latitude": -31.3823246,
-    "longitude": 131.3940891
+    "geo_long": 5.6343227
   },
   {
     "id": "A2iTV.it",
@@ -499,9 +429,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 42.6384261,
-    "geo_long": 12.674297,
-    "latitude": 45.2502495,
-    "longitude": 4.2558503
+    "geo_long": 12.674297
   },
   {
     "id": "A2TV.tr",
@@ -513,9 +441,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.294076,
-    "geo_long": 35.2316631,
-    "latitude": 25.029422,
-    "longitude": -77.361956
+    "geo_long": 35.2316631
   },
   {
     "id": "A7TV.ro@SD",
@@ -527,9 +453,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 25.0364755,
-    "geo_long": 121.5660652,
-    "latitude": 55.7440885,
-    "longitude": -2.911116
+    "geo_long": 121.5660652
   },
   {
     "id": "A12TV.ci@SD",
@@ -540,10 +464,8 @@
     "city": "A12",
     "categories": "General",
     "type": "tv",
-    "geo_lat": 42.0066871,
-    "geo_long": 12.0308307,
-    "latitude": 25.029422,
-    "longitude": -77.361956
+    "geo_lat": 42.0089456,
+    "geo_long": 12.0259486
   },
   {
     "id": "APunt.es@SD",
@@ -555,23 +477,19 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.5121647,
-    "geo_long": -0.4246933,
-    "latitude": 39.5121647,
-    "longitude": -0.4246933
+    "geo_long": -0.4246933
   },
   {
     "id": "APlusGuate.gt",
     "name": "A+ Guate (720p)",
     "url": "https://ch2-tva.duin.dev/hls/stream.m3u8",
     "logo": "https://i.imgur.com/BtGK7iZ.png",
-    "country": "Unknown",
-    "city": "A Guate 720p",
+    "country": "Guatemala",
+    "city": "Guatemala City",
     "categories": "General",
     "type": "tv",
     "geo_lat": 14.6416142,
-    "geo_long": -90.5132836,
-    "latitude": 15.5855545,
-    "longitude": -90.345759
+    "geo_long": -90.5132836
   },
   {
     "id": "ABC.us",
@@ -583,23 +501,19 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.7837304,
-    "geo_long": -100.445882,
-    "latitude": -27.4756481,
-    "longitude": 153.0203484
+    "geo_long": -100.445882
   },
   {
     "id": "KATCDT1.us",
     "name": "ABC 3 Lafayette LA (KATC) (720p)",
     "url": "https://aegis-cloudfront-1.tubi.video/28467730-4b65-4c85-8151-4c7d162c0896/playlist.m3u8",
     "logo": "https://upload.wikimedia.org/wikipedia/commons/2/27/WWAY_logo.png",
-    "country": "United States",
-    "city": "Lafayette",
+    "country": "Unknown",
+    "city": "ABC 3 Lafayette LA KATC 720p",
     "categories": "General",
     "type": "tv",
-    "geo_lat": 30.20806,
-    "geo_long": -92.03250,
-    "latitude": 30.20806,
-    "longitude": -92.03250
+    "geo_lat": 30.2262187,
+    "geo_long": -92.0178202
   },
   {
     "id": "KRGVDT1.us",
@@ -611,9 +525,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.7837304,
-    "geo_long": -100.445882,
-    "latitude": 52.6389604,
-    "longitude": 5.0697394
+    "geo_long": -100.445882
   },
   {
     "id": "KMGHDT1.us",
@@ -625,9 +537,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.7392364,
-    "geo_long": -104.984862,
-    "latitude": 39.7392,
-    "longitude": -104.9903
+    "geo_long": -104.984862
   },
   {
     "id": "KTNVDT1.us",
@@ -639,9 +549,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 36.1674263,
-    "geo_long": -115.1484131,
-    "latitude": 36.1699,
-    "longitude": -115.1398
+    "geo_long": -115.1484131
   },
   {
     "id": "KNXVDT1.us",
@@ -653,23 +561,19 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 33.4484367,
-    "geo_long": -112.074141,
-    "latitude": 33.4484,
-    "longitude": -112.074
+    "geo_long": -112.074141
   },
   {
     "id": "KXXVDT1.us",
     "name": "ABC 25 News Central Texas",
     "url": "https://content.uplynk.com/channel/9d4e02c9c3544c269d32e6b316792c8f.m3u8",
     "logo": "https://upload.wikimedia.org/wikipedia/commons/2/27/WWAY_logo.png",
-    "country": "United States",
+    "country": "Unknown",
     "city": "ABC 25 News Central Texas",
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.7837304,
-    "geo_long": -100.445882,
-    "latitude": 37.0902,
-    "longitude": -95.7129
+    "geo_long": -100.445882
   },
   {
     "id": "ABCAustralia.au",
@@ -681,23 +585,19 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -24.7761086,
-    "geo_long": 134.755,
-    "latitude": -27.4756481,
-    "longitude": 153.0203484
+    "geo_long": 134.755
   },
   {
     "id": "ABCAustralia.au@Vietnam",
     "name": "ABC Australia Vietnam (1080p)",
     "url": "https://hls.mskycdn.online/tv/abcaustralia/index.m3u8",
     "logo": "https://i.imgur.com/qQ33TVM.png",
-    "country": "Unknown",
-    "city": "ABC Australia Vietnam 1080p",
+    "country": "Australia",
+    "city": "Sydney",
     "categories": "General",
     "type": "tv",
     "geo_lat": -33.8698439,
-    "geo_long": 151.2082848,
-    "latitude": 14.0583,
-    "longitude": 108.2772
+    "geo_long": 151.2082848
   },
   {
     "id": "ABCTV.au@Adelaide",
@@ -709,9 +609,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -27.4756481,
-    "geo_long": 153.0203484,
-    "latitude": -27.4756481,
-    "longitude": 153.0203484
+    "geo_long": 153.0203484
   },
   {
     "id": "ABCTV.au@Brisbane",
@@ -723,9 +621,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -27.4756481,
-    "geo_long": 153.0203484,
-    "latitude": -27.4756481,
-    "longitude": 153.0203484
+    "geo_long": 153.0203484
   },
   {
     "id": "ABCTV.au",
@@ -737,9 +633,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -24.7761086,
-    "geo_long": 134.755,
-    "latitude": -27.4756481,
-    "longitude": 153.0203484
+    "geo_long": 134.755
   },
   {
     "id": "ABCTV.au@Hobart",
@@ -751,9 +645,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -27.4756481,
-    "geo_long": 153.0203484,
-    "latitude": -27.4756481,
-    "longitude": 153.0203484
+    "geo_long": 153.0203484
   },
   {
     "id": "ABCTV.au@Melbourne",
@@ -765,9 +657,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -27.4756481,
-    "geo_long": 153.0203484,
-    "latitude": -27.4756481,
-    "longitude": 153.0203484
+    "geo_long": 153.0203484
   },
   {
     "id": "ABCTV.au@Perth",
@@ -779,9 +669,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -27.4756481,
-    "geo_long": 153.0203484,
-    "latitude": -27.4756481,
-    "longitude": 153.0203484
+    "geo_long": 153.0203484
   },
   {
     "id": "ABN.kr",
@@ -793,37 +681,31 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 36.638392,
-    "geo_long": 127.6961188,
-    "latitude": 37.3324374,
-    "longitude": 42.1854699
+    "geo_long": 127.6961188
   },
   {
     "id": "AbuDhabiAloula.ae@SD",
     "name": "Abu Dhabi Aloula (1080p)",
     "url": "https://vo-live-media.cdb.cdn.orange.com/Content/Channel/AbuDhabiChannel/HLS/index.m3u8",
     "logo": "https://i.imgur.com/g7IRorO.jpeg",
-    "country": "Unknown",
-    "city": "Abu Dhabi Aloula 1080p",
+    "country": "UAE",
+    "city": "Abu Dhabi",
     "categories": "General",
     "type": "tv",
     "geo_lat": 24.4538352,
-    "geo_long": 54.3774014,
-    "latitude": 24.4539,
-    "longitude": 54.3773
+    "geo_long": 54.3774014
   },
   {
     "id": "AbuDhabiEmirates.ae@SD",
     "name": "Abu Dhabi Emirates (1080p)",
     "url": "https://vo-live-media.cdb.cdn.orange.com/Content/Channel/EmiratesChannel/HLS/index.m3u8",
     "logo": "https://i.imgur.com/OT6DW3E.png",
-    "country": "Unknown",
-    "city": "Abu Dhabi Emirates 1080p",
+    "country": "UAE",
+    "city": "Abu Dhabi",
     "categories": "General",
     "type": "tv",
     "geo_lat": 24.4538352,
-    "geo_long": 54.3774014,
-    "latitude": 24.4539,
-    "longitude": 54.3773
+    "geo_long": 54.3774014
   },
   {
     "id": "AbuDhabiTV.ae@SD",
@@ -835,9 +717,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 24.4538352,
-    "geo_long": 54.3774014,
-    "latitude": 24.4538352,
-    "longitude": 54.3774014
+    "geo_long": 54.3774014
   },
   {
     "id": "AccessHumboldt.us",
@@ -849,9 +729,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.7837304,
-    "geo_long": -100.445882,
-    "latitude": 40.7459,
-    "longitude": -123.8665
+    "geo_long": -100.445882
   },
   {
     "id": "AMP1.us",
@@ -863,9 +741,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.7837304,
-    "geo_long": -100.445882,
-    "latitude": 36.7783,
-    "longitude": -119.4179
+    "geo_long": -100.445882
   },
   {
     "id": "TheMontereyChannel.us",
@@ -877,9 +753,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.7837304,
-    "geo_long": -100.445882,
-    "latitude": 36.6002,
-    "longitude": -121.8947
+    "geo_long": -100.445882
   },
   {
     "id": "AccessNashua.us",
@@ -891,9 +765,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.7837304,
-    "geo_long": -100.445882,
-    "latitude": 42.7011896,
-    "longitude": -71.5419933
+    "geo_long": -100.445882
   },
   {
     "id": "AccessSacramentoChannel17.us",
@@ -905,9 +777,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.7837304,
-    "geo_long": -100.445882,
-    "latitude": 38.5816,
-    "longitude": -121.4944
+    "geo_long": -100.445882
   },
   {
     "id": "AccessSacramentoChannel18.us",
@@ -919,9 +789,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.7837304,
-    "geo_long": -100.445882,
-    "latitude": 38.5816,
-    "longitude": -121.4944
+    "geo_long": -100.445882
   },
   {
     "id": "AccessTuolumne.us",
@@ -933,9 +801,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.7837304,
-    "geo_long": -100.445882,
-    "latitude": 37.9643,
-    "longitude": -120.4036
+    "geo_long": -100.445882
   },
   {
     "id": "AccessVisionChannel16.us",
@@ -947,9 +813,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.7837304,
-    "geo_long": -100.445882,
-    "latitude": 34.0522,
-    "longitude": -118.2437
+    "geo_long": -100.445882
   },
   {
     "id": "AcheloosTV.gr",
@@ -961,37 +825,31 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 38.9953683,
-    "geo_long": 21.9877132,
-    "latitude": 39.0128349,
-    "longitude": 21.3793216
+    "geo_long": 21.9877132
   },
   {
     "id": "ACTV.be",
     "name": "ACTV [Geo-blocked]",
     "url": "https://tvlocales-live.freecaster.com/live/95d2f733-1bc2-4bd5-9b96-c53ed3fc450f/95d2f733-1bc2-4bd5-9b96-c53ed3fc450f.isml/master.m3u8",
     "logo": "https://files.catbox.moe/8v2y8m.png",
-    "country": "Unknown",
-    "city": "ACTV Geo",
+    "country": "Belgium",
+    "city": "Wallonia",
     "categories": "General",
     "type": "tv",
     "geo_lat": 50.1545523,
-    "geo_long": 5.3992119,
-    "latitude": 50.6402809,
-    "longitude": 4.6667145
+    "geo_long": 5.3992119
   },
   {
     "id": "ACWUGTV.ug",
     "name": "ACW UG TV (480p)",
     "url": "https://live.acwugtv.com/hls/stream.m3u8",
     "logo": "https://i.imgur.com/8pzEmcJ.jpeg",
-    "country": "Unknown",
-    "city": "ACW UG",
+    "country": "Uganda",
+    "city": "Kampala",
     "categories": "General;Music",
     "type": "tv",
     "geo_lat": 0.3177137,
-    "geo_long": 32.5813539,
-    "latitude": 1.5333554,
-    "longitude": 32.2166578
+    "geo_long": 32.5813539
   },
   {
     "id": "AdaTV.cy",
@@ -1003,9 +861,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 34.9174159,
-    "geo_long": 32.8899027,
-    "latitude": 43.4136539,
-    "longitude": -116.2367421
+    "geo_long": 32.8899027
   },
   {
     "id": "AddisTV.et",
@@ -1017,9 +873,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 10.2116702,
-    "geo_long": 38.6521203,
-    "latitude": 9.0202838,
-    "longitude": 38.8166003
+    "geo_long": 38.6521203
   },
   {
     "id": "AdessoTV.br",
@@ -1031,23 +885,19 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -10.3333333,
-    "geo_long": -53.2,
-    "latitude": 51.457886,
-    "longitude": -0.3048221
+    "geo_long": -53.2
   },
   {
     "id": "AdomTV.gh@SD",
     "name": "Adom TV",
     "url": "https://live20.bozztv.com/dvrfl06/astv/astv-adom/index.m3u8",
     "logo": "https://i.imgur.com/y0LQm3p.png",
-    "country": "Ghana",
+    "country": "Unknown",
     "city": "Adom",
     "categories": "General",
     "type": "tv",
     "geo_lat": 7.4687328,
-    "geo_long": -2.5983739,
-    "latitude": 0,
-    "longitude": 0
+    "geo_long": -2.5983739
   },
   {
     "id": "AfaqTV.iq",
@@ -1059,9 +909,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 33.0955793,
-    "geo_long": 44.1749775,
-    "latitude": 25.338451,
-    "longitude": 55.4021377
+    "geo_long": 44.1749775
   },
   {
     "id": "AfghanNobelTV.ca",
@@ -1073,9 +921,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 61.0666922,
-    "geo_long": -107.991707,
-    "latitude": 34.5553,
-    "longitude": 69.2075
+    "geo_long": -107.991707
   },
   {
     "id": "AfricableTV.ml",
@@ -1087,9 +933,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 12.607137,
-    "geo_long": -7.97397,
-    "latitude": 12.607137,
-    "longitude": -7.97397
+    "geo_long": -7.97397
   },
   {
     "id": "AfroturkTV.tr",
@@ -1101,9 +945,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.294076,
-    "geo_long": 35.2316631,
-    "latitude": 39.294076,
-    "longitude": 35.2316631
+    "geo_long": 35.2316631
   },
   {
     "id": "AhoraTV.do",
@@ -1115,9 +957,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.7752584,
-    "geo_long": 44.3786842,
-    "latitude": 39.7752584,
-    "longitude": 44.3786842
+    "geo_long": 44.3786842
   },
   {
     "id": "AIONTV.do",
@@ -1129,9 +969,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 69.7808467,
-    "geo_long": 168.6785306,
-    "latitude": 69.7808467,
-    "longitude": 168.6785306
+    "geo_long": 168.6785306
   },
   {
     "id": "AiredeSantaFe.ar",
@@ -1143,9 +981,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -34.9964963,
-    "geo_long": -64.9672817,
-    "latitude": -34.9964963,
-    "longitude": -64.9672817
+    "geo_long": -64.9672817
   },
   {
     "id": "AjmanTV.ae",
@@ -1157,23 +993,19 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 24.0002488,
-    "geo_long": 53.9994829,
-    "latitude": 25.5091287,
-    "longitude": 55.3619072
+    "geo_long": 53.9994829
   },
   {
     "id": "AjyalTV.ps",
     "name": "Ajyal TV (720p)",
     "url": "http://htvmada.mada.ps:8888/ajyal/index.m3u8",
     "logo": "https://i.imgur.com/i6Y7beR.jpg",
-    "country": "Palestine",
-    "city": "Gaza",
+    "country": "Unknown",
+    "city": "Ajyal",
     "categories": "General",
     "type": "tv",
-    "geo_lat": 31.517,
-    "geo_long": 34.450,
-    "latitude": 31.517,
-    "longitude": 34.450
+    "geo_lat": 31.7621153,
+    "geo_long": -95.6307891
   },
   {
     "id": "Akaku53.us",
@@ -1185,9 +1017,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.7837304,
-    "geo_long": -100.445882,
-    "latitude": 21.3069,
-    "longitude": -157.8583
+    "geo_long": -100.445882
   },
   {
     "id": "Akaku54.us",
@@ -1199,9 +1029,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.7837304,
-    "geo_long": -100.445882,
-    "latitude": 21.3069,
-    "longitude": -157.8583
+    "geo_long": -100.445882
   },
   {
     "id": "Akaku55.us",
@@ -1213,9 +1041,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.7837304,
-    "geo_long": -100.445882,
-    "latitude": 21.3069,
-    "longitude": -157.8583
+    "geo_long": -100.445882
   },
   {
     "id": "AksuTV.tr",
@@ -1227,9 +1053,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.294076,
-    "geo_long": 35.2316631,
-    "latitude": 41.1677575,
-    "longitude": 80.2582136
+    "geo_long": 35.2316631
   },
   {
     "id": "AKTV.id",
@@ -1241,9 +1065,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -2.4833826,
-    "geo_long": 117.8902853,
-    "latitude": 65.3061851,
-    "longitude": -145.4182743
+    "geo_long": 117.8902853
   },
   {
     "id": "AlahadTV.iq",
@@ -1255,51 +1077,43 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 33.0955793,
-    "geo_long": 44.1749775,
-    "latitude": 14.2555602,
-    "longitude": 43.6425238
+    "geo_long": 44.1749775
   },
   {
     "id": "AlAoula.ma@Inter",
     "name": "Al Aoula Inter (480p)",
     "url": "https://cdn.live.easybroadcast.io/ts_corp/73_aloula_w1dqfwm/playlist_dvr.m3u8",
     "logo": "https://i.imgur.com/nq53d2N.png",
-    "country": "Unknown",
-    "city": "Al Aoula Inter 480p",
+    "country": "Morocco",
+    "city": "Rabat",
     "categories": "General",
     "type": "tv",
     "geo_lat": 34.0218454,
-    "geo_long": -6.8408929,
-    "latitude": 31.7917,
-    "longitude": -7.0926
+    "geo_long": -6.8408929
   },
   {
     "id": "LaayouneTV.ma@SD",
     "name": "Al Aoula Laâyoune (480p)",
     "url": "https://cdn.live.easybroadcast.io/abr_corp/73_laayoune_pgagr52/corp/73_laayoune_pgagr52_480p/chunks_dvr.m3u8",
     "logo": "https://www.snrt.ma/sites/default/files/2023-04/laayoune.png",
-    "country": "Unknown",
-    "city": "Al Aoula Layoune 480p",
+    "country": "Morocco",
+    "city": "Laayoune",
     "categories": "General",
     "type": "tv",
     "geo_lat": 27.154512,
-    "geo_long": -13.1953921,
-    "latitude": 27.1536,
-    "longitude": -13.2036
+    "geo_long": -13.1953921
   },
   {
     "id": "AlAqsaTV.ps",
     "name": "Al Aqsa Channel (416p) [Not 24/7]",
     "url": "http://167.172.161.13/hls/feedspare/6udfi7v8a3eof6nlps6e9ovfrs65c7l7.m3u8",
     "logo": "https://i.imgur.com/Z2rfrQ8.png",
-    "country": "Palestine",
-    "city": "Gaza",
+    "country": "Unknown",
+    "city": "Al Aqsa Channel 416p Not 247",
     "categories": "General",
     "type": "tv",
-    "geo_lat": 31.517,
-    "geo_long": 34.450,
-    "latitude": 31.517,
-    "longitude": 34.450
+    "geo_lat": 31.7621153,
+    "geo_long": -95.6307891
   },
   {
     "id": "AlDafrahTV.ae",
@@ -1311,9 +1125,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 24.0002488,
-    "geo_long": 53.9994829,
-    "latitude": 30.7265806,
-    "longitude": 31.0245514
+    "geo_long": 53.9994829
   },
   {
     "id": "AlIraqia.iq",
@@ -1325,9 +1137,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 33.0955793,
-    "geo_long": 44.1749775,
-    "latitude": 33.0955793,
-    "longitude": 44.1749775
+    "geo_long": 44.1749775
   },
   {
     "id": "AlIttihadTV.lb",
@@ -1339,37 +1149,31 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 33.8750629,
-    "geo_long": 35.843409,
-    "latitude": 33.8750629,
-    "longitude": 35.843409
+    "geo_long": 35.843409
   },
   {
     "id": "AlJadeed.lb@SD",
     "name": "Al Jadeed (1080p)",
     "url": "http://185.9.2.18/chid_391/mono.m3u8",
     "logo": "https://i.imgur.com/CfxR8o3.png",
-    "country": "Unknown",
-    "city": "Al Jadeed 1080p",
+    "country": "Lebanon",
+    "city": "Beirut",
     "categories": "General",
     "type": "tv",
     "geo_lat": 33.8892265,
-    "geo_long": 35.5025585,
-    "latitude": 33.8938,
-    "longitude": 35.5018
+    "geo_long": 35.5025585
   },
   {
     "id": "AlMaghribia.ma@SD",
     "name": "Al Maghribia (480p)",
     "url": "https://cdn.live.easybroadcast.io/abr_corp/73_almaghribia_83tz85q/corp/73_almaghribia_83tz85q_480p/chunks_dvr.m3u8",
     "logo": "https://i.imgur.com/7GaahYh.png",
-    "country": "Unknown",
-    "city": "Al Maghribia 480p",
+    "country": "Morocco",
+    "city": "Rabat",
     "categories": "General",
     "type": "tv",
     "geo_lat": 34.0218454,
-    "geo_long": -6.8408929,
-    "latitude": 31.7917,
-    "longitude": -7.0926
+    "geo_long": -6.8408929
   },
   {
     "id": "AlMasriyah.eg@SD",
@@ -1381,9 +1185,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 5.3733777,
-    "geo_long": 100.4635261,
-    "latitude": 5.3733777,
-    "longitude": 100.4635261
+    "geo_long": 100.4635261
   },
   {
     "id": "AlRabiaaTV.iq",
@@ -1395,9 +1197,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 33.0955793,
-    "geo_long": 44.1749775,
-    "latitude": 30.3690691,
-    "longitude": -9.5351991
+    "geo_long": 44.1749775
   },
   {
     "id": "AlRasheedTV.iq",
@@ -1409,9 +1209,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 33.0955793,
-    "geo_long": 44.1749775,
-    "latitude": 33.2612817,
-    "longitude": 44.3322542
+    "geo_long": 44.1749775
   },
   {
     "id": "AlRayyanTV.qa",
@@ -1423,9 +1221,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 25.3336984,
-    "geo_long": 51.2295295,
-    "latitude": 25.3336984,
-    "longitude": 51.2295295
+    "geo_long": 51.2295295
   },
   {
     "id": "AlRayyanOldTV.qa",
@@ -1437,9 +1233,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 25.3336984,
-    "geo_long": 51.2295295,
-    "latitude": 25.3336984,
-    "longitude": 51.2295295
+    "geo_long": 51.2295295
   },
   {
     "id": "AlSaudiya.sa",
@@ -1451,9 +1245,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 25.6242618,
-    "geo_long": 42.3528328,
-    "latitude": 25.6242618,
-    "longitude": 42.3528328
+    "geo_long": 42.3528328
   },
   {
     "id": "AlShallalTV.ae",
@@ -1465,9 +1257,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 24.0002488,
-    "geo_long": 53.9994829,
-    "latitude": 42.3416495,
-    "longitude": -83.2773033
+    "geo_long": 53.9994829
   },
   {
     "id": "AlSharqiyaMinKabla.ae",
@@ -1479,9 +1269,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 24.0002488,
-    "geo_long": 53.9994829,
-    "latitude": 24.0002488,
-    "longitude": 53.9994829
+    "geo_long": 53.9994829
   },
   {
     "id": "AlWoustaTV.ae",
@@ -1493,9 +1281,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 24.0002488,
-    "geo_long": 53.9994829,
-    "latitude": 24.0002488,
-    "longitude": 53.9994829
+    "geo_long": 53.9994829
   },
   {
     "id": "AlSharqiya.iq",
@@ -1507,9 +1293,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 33.0955793,
-    "geo_long": 44.1749775,
-    "latitude": 41.328203,
-    "longitude": 19.8219052
+    "geo_long": 44.1749775
   },
   {
     "id": "AlacantiTV.es",
@@ -1521,9 +1305,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.3260685,
-    "geo_long": -4.8379791,
-    "latitude": 38.3436365,
-    "longitude": -0.4881708
+    "geo_long": -4.8379791
   },
   {
     "id": "AlanyaPostaTV.tr",
@@ -1535,9 +1317,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.294076,
-    "geo_long": 35.2316631,
-    "latitude": 36.4840521,
-    "longitude": 32.1030524
+    "geo_long": 35.2316631
   },
   {
     "id": "AlbdreamsTV.us",
@@ -1549,9 +1329,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.7837304,
-    "geo_long": -100.445882,
-    "latitude": 41.1533,
-    "longitude": 20.1683
+    "geo_long": -100.445882
   },
   {
     "id": "AlborzTV.ir",
@@ -1563,9 +1341,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 32.6475314,
-    "geo_long": 54.5643516,
-    "latitude": 35.956,
-    "longitude": 52.1086
+    "geo_long": 54.5643516
   },
   {
     "id": "AlbUKTV.uk",
@@ -1577,9 +1353,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 54.7023545,
-    "geo_long": -3.2765753,
-    "latitude": 54.7023545,
-    "longitude": -3.2765753
+    "geo_long": -3.2765753
   },
   {
     "id": "AlcarriaTV.es",
@@ -1591,9 +1365,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.3260685,
-    "geo_long": -4.8379791,
-    "latitude": 42.2505145,
-    "longitude": -3.6916617
+    "geo_long": -4.8379791
   },
   {
     "id": "AlForatTV.iq",
@@ -1605,9 +1377,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 33.0955793,
-    "geo_long": 44.1749775,
-    "latitude": 32.8581077,
-    "longitude": 35.3093085
+    "geo_long": 44.1749775
   },
   {
     "id": "AlhayatTV.eg@SD",
@@ -1619,9 +1389,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 51.4877215,
-    "geo_long": -0.1404017,
-    "latitude": 51.4877215,
-    "longitude": -0.1404017
+    "geo_long": -0.1404017
   },
   {
     "id": "AllgauTV.de",
@@ -1633,9 +1401,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 51.1638175,
-    "geo_long": 10.4478313,
-    "latitude": 51.1638175,
-    "longitude": 10.4478313
+    "geo_long": 10.4478313
   },
   {
     "id": "AlpedHuezTV.fr",
@@ -1647,9 +1413,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 46.603354,
-    "geo_long": 1.8883335,
-    "latitude": 46.603354,
-    "longitude": 1.8883335
+    "geo_long": 1.8883335
   },
   {
     "id": "AlphaChannel.br",
@@ -1661,9 +1425,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -10.3333333,
-    "geo_long": -53.2,
-    "latitude": -10.3333333,
-    "longitude": -53.2
+    "geo_long": -53.2
   },
   {
     "id": "AlsaciasTelevision.hn",
@@ -1675,37 +1437,31 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 15.2572432,
-    "geo_long": -86.0755145,
-    "latitude": 15.2572432,
-    "longitude": -86.0755145
+    "geo_long": -86.0755145
   },
   {
     "id": "AlShoub.eg@SD",
     "name": "AlShoub (720p)",
     "url": "https://play.tactivemedia.com/memfs/c5919b97-5329-4b84-91b2-613c6ed9953e.m3u8",
     "logo": "https://alshoub.tv/wp-content/uploads/2023/09/logo@2x-1-1.png",
-    "country": "Unknown",
-    "city": "AlShoub 720p",
+    "country": "Egypt",
+    "city": "Cairo",
     "categories": "General",
     "type": "tv",
     "geo_lat": 30.0443879,
-    "geo_long": 31.2357257,
-    "latitude": 35.8617,
-    "longitude": 104.1954
+    "geo_long": 31.2357257
   },
   {
     "id": "AltantoTV.do",
     "name": "Altanto TV (720p)",
     "url": "https://streaming.altantotv.domiplay.net/hls/0/stream.m3u8",
     "logo": "https://i.imgur.com/KWvVLhc.png",
-    "country": "Unknown",
-    "city": "Altanto",
+    "country": "Dominican Republic",
+    "city": "Santo Domingo",
     "categories": "General",
     "type": "tv",
     "geo_lat": 18.4801972,
-    "geo_long": -69.942111,
-    "latitude": 19.0974031,
-    "longitude": -70.3028026
+    "geo_long": -69.942111
   },
   {
     "id": "AltasTV.tr",
@@ -1717,9 +1473,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.294076,
-    "geo_long": 35.2316631,
-    "latitude": 41.1614725,
-    "longitude": 42.8742926
+    "geo_long": 35.2316631
   },
   {
     "id": "AltenburgTV.de",
@@ -1731,9 +1485,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 51.1638175,
-    "geo_long": 10.4478313,
-    "latitude": 50.9852411,
-    "longitude": 12.4340988
+    "geo_long": 10.4478313
   },
   {
     "id": "AlternaTV.ar",
@@ -1745,9 +1497,7 @@
     "categories": "Culture;Documentary;Entertainment;General;Movies;Music",
     "type": "tv",
     "geo_lat": -34.9964963,
-    "geo_long": -64.9672817,
-    "latitude": -2.2251708,
-    "longitude": -80.939872
+    "geo_long": -64.9672817
   },
   {
     "id": "Althania.sy",
@@ -1759,9 +1509,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 34.8147886,
-    "geo_long": 38.4231781,
-    "latitude": 34.8147886,
-    "longitude": 38.4231781
+    "geo_long": 38.4231781
   },
   {
     "id": "AltoAdigeTV.it",
@@ -1773,23 +1521,19 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 42.6384261,
-    "geo_long": 12.674297,
-    "latitude": 46.6559455,
-    "longitude": 11.2302129
+    "geo_long": 12.674297
   },
   {
     "id": "AltynAsyr.tm",
     "name": "Altyn Asyr (406p) [Not 24/7]",
     "url": "https://alpha.tv.online.tm/hls/ch001.m3u8",
     "logo": "https://i.imgur.com/D7RBtZ2.png",
-    "country": "Unknown",
-    "city": "Altyn Asyr 406p Not 247",
+    "country": "Turkmenistan",
+    "city": "Ashgabat",
     "categories": "General",
     "type": "tv",
     "geo_lat": 37.9404648,
-    "geo_long": 58.3823487,
-    "latitude": 37.9605,
-    "longitude": 58.3283
+    "geo_long": 58.3823487
   },
   {
     "id": "AlvinChannelTV.az",
@@ -1801,9 +1545,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 40.3936294,
-    "geo_long": 47.7872508,
-    "latitude": 29.4241,
-    "longitude": -95.2702
+    "geo_long": 47.7872508
   },
   {
     "id": "Ame47.do@SD",
@@ -1815,9 +1557,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 34.6937,
-    "geo_long": 135.5023,
-    "latitude": 34.6937,
-    "longitude": 135.5023
+    "geo_long": 135.5023
   },
   {
     "id": "AmericaEstereoGuayaquil.ec",
@@ -1829,9 +1569,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -1.3397668,
-    "geo_long": -79.3666965,
-    "latitude": -1.3397668,
-    "longitude": -79.3666965
+    "geo_long": -79.3666965
   },
   {
     "id": "AmericaEstereoIbarra.ec",
@@ -1843,9 +1581,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -1.3397668,
-    "geo_long": -79.3666965,
-    "latitude": -1.3397668,
-    "longitude": -79.3666965
+    "geo_long": -79.3666965
   },
   {
     "id": "AmericaEstereoTulcan.ec",
@@ -1857,9 +1593,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -1.3397668,
-    "geo_long": -79.3666965,
-    "latitude": -1.3397668,
-    "longitude": -79.3666965
+    "geo_long": -79.3666965
   },
   {
     "id": "AmericaTelevision.pe@SD",
@@ -1871,23 +1605,19 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -5.1951731,
-    "geo_long": -80.6305309,
-    "latitude": -5.1951731,
-    "longitude": -80.6305309
+    "geo_long": -80.6305309
   },
   {
     "id": "AmericaTeVe.pr",
     "name": "América TeVé (1080p)",
     "url": "https://live.gideo.video/americateve2/master.m3u8",
     "logo": "https://i.imgur.com/K9o3mLP.png",
-    "country": "Unknown",
-    "city": "Amrica TeV 1080p",
+    "country": "Puerto Rico",
+    "city": "San Juan",
     "categories": "Entertainment;General",
     "type": "tv",
     "geo_lat": 18.384239,
-    "geo_long": -66.05344,
-    "latitude": 25.7617,
-    "longitude": -80.1918
+    "geo_long": -66.05344
   },
   {
     "id": "AMGATV.us",
@@ -1899,9 +1629,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.7837304,
-    "geo_long": -100.445882,
-    "latitude": 60.894218,
-    "longitude": 131.97998
+    "geo_long": -100.445882
   },
   {
     "id": "AmmanTV.jo",
@@ -1913,23 +1641,19 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 31.1667049,
-    "geo_long": 36.941628,
-    "latitude": 31.9515694,
-    "longitude": 35.9239625
+    "geo_long": 36.941628
   },
   {
     "id": "AmouzeshTV.ir@SD",
     "name": "Amouzesh TV",
     "url": "http://dvrfl05.bozztv.com/gin-iribamoozesh/index.m3u8",
     "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/5/5b/Amouzesh_TV_logo_%282023%29.svg/201px-Amouzesh_TV_logo_%282023%29.svg.png",
-    "country": "Unknown",
-    "city": "Amouzesh",
+    "country": "Iran",
+    "city": "Tehran",
     "categories": "General",
     "type": "tv",
     "geo_lat": 35.6892523,
-    "geo_long": 51.3896004,
-    "latitude": 35.6892,
-    "longitude": 51.389
+    "geo_long": 51.3896004
   },
   {
     "id": "AnadoluDernekTV.tr",
@@ -1941,9 +1665,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.294076,
-    "geo_long": 35.2316631,
-    "latitude": 37.2104195,
-    "longitude": 37.6902981
+    "geo_long": 35.2316631
   },
   {
     "id": "AnadoluNetTV.tr",
@@ -1955,9 +1677,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.294076,
-    "geo_long": 35.2316631,
-    "latitude": 39.9589508,
-    "longitude": 32.8896557
+    "geo_long": 35.2316631
   },
   {
     "id": "AnandTV.uk",
@@ -1969,9 +1689,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 54.7023545,
-    "geo_long": -3.2765753,
-    "latitude": 22.5586555,
-    "longitude": 72.9627227
+    "geo_long": -3.2765753
   },
   {
     "id": "Antena1.ro",
@@ -1983,23 +1701,19 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 45.9852129,
-    "geo_long": 24.6859225,
-    "latitude": 45.9852129,
-    "longitude": 24.6859225
+    "geo_long": 24.6859225
   },
   {
     "id": "Antena3Internacional.es@SD",
     "name": "Antena 3 Internacional (480p)",
     "url": "http://38.180.133.31:8000/play/a0ki/index.m3u8",
     "logo": "https://i.imgur.com/QMadWXp.png",
-    "country": "Unknown",
-    "city": "Antena 3 Internacional 480p",
+    "country": "Spain",
+    "city": "Madrid",
     "categories": "General",
     "type": "tv",
     "geo_lat": 40.4167047,
-    "geo_long": -3.7035825,
-    "latitude": 40.4168,
-    "longitude": -3.7038
+    "geo_long": -3.7035825
   },
   {
     "id": "Antena7.do",
@@ -2011,9 +1725,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -16.4975395,
-    "geo_long": -68.1055452,
-    "latitude": -16.4975395,
-    "longitude": -68.1055452
+    "geo_long": -68.1055452
   },
   {
     "id": "AntenaSeisTV.cr",
@@ -2025,9 +1737,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 10.2735633,
-    "geo_long": -84.0739102,
-    "latitude": 10.2735633,
-    "longitude": -84.0739102
+    "geo_long": -84.0739102
   },
   {
     "id": "AntenaTV.mx",
@@ -2039,9 +1749,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 23.6585116,
-    "geo_long": -102.0077097,
-    "latitude": -45.8540211,
-    "longitude": -67.5132878
+    "geo_long": -102.0077097
   },
   {
     "id": "Antenna2TV.it",
@@ -2053,9 +1761,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 42.6384261,
-    "geo_long": 12.674297,
-    "latitude": 33.255398,
-    "longitude": -81.0753
+    "geo_long": 12.674297
   },
   {
     "id": "AntennaTre.it",
@@ -2067,9 +1773,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 42.6384261,
-    "geo_long": 12.674297,
-    "latitude": 42.6384261,
-    "longitude": 12.674297
+    "geo_long": 12.674297
   },
   {
     "id": "AntofagastaTV.cl",
@@ -2081,9 +1785,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -31.7613365,
-    "geo_long": -71.3187697,
-    "latitude": -23.6463741,
-    "longitude": -70.3980033
+    "geo_long": -71.3187697
   },
   {
     "id": "AnzoateguiTV.ve",
@@ -2095,9 +1797,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 8.0018709,
-    "geo_long": -66.1109318,
-    "latitude": 8.0018709,
-    "longitude": -66.1109318
+    "geo_long": -66.1109318
   },
   {
     "id": "ApprovalTV.ng",
@@ -2109,9 +1809,7 @@
     "categories": "General;Religious",
     "type": "tv",
     "geo_lat": 9.6000359,
-    "geo_long": 7.9999721,
-    "latitude": 45.3674123,
-    "longitude": -75.7867255
+    "geo_long": 7.9999721
   },
   {
     "id": "Aqjaiyq.kz",
@@ -2123,9 +1821,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 48.1012954,
-    "geo_long": 66.7780818,
-    "latitude": 44.5217,
-    "longitude": 65.2275
+    "geo_long": 66.7780818
   },
   {
     "id": "Aqtobe.kz",
@@ -2137,9 +1833,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 48.1012954,
-    "geo_long": 66.7780818,
-    "latitude": 50.2707,
-    "longitude": 57.2182
+    "geo_long": 66.7780818
   },
   {
     "id": "AraTV.ir",
@@ -2151,9 +1845,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 32.6475314,
-    "geo_long": 54.5643516,
-    "latitude": 12.9489302,
-    "longitude": 77.7085732
+    "geo_long": 54.5643516
   },
   {
     "id": "ArabiTV.es",
@@ -2165,9 +1857,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.3260685,
-    "geo_long": -4.8379791,
-    "latitude": 34.3181497,
-    "longitude": -86.4958219
+    "geo_long": -4.8379791
   },
   {
     "id": "AragonTV.es@SD",
@@ -2179,9 +1869,7 @@
     "categories": "General;Public",
     "type": "tv",
     "geo_lat": 41.3787291,
-    "geo_long": -0.7639373,
-    "latitude": 41.3787291,
-    "longitude": -0.7639373
+    "geo_long": -0.7639373
   },
   {
     "id": "ArasTV.tr",
@@ -2193,9 +1881,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.294076,
-    "geo_long": 35.2316631,
-    "latitude": 39.6293745,
-    "longitude": 44.8088337
+    "geo_long": 35.2316631
   },
   {
     "id": "ARB.az",
@@ -2207,9 +1893,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 40.3936294,
-    "geo_long": 47.7872508,
-    "latitude": 50.2839639,
-    "longitude": 7.0445739
+    "geo_long": 47.7872508
   },
   {
     "id": "ArdealTV.ro",
@@ -2221,9 +1905,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 45.9852129,
-    "geo_long": 24.6859225,
-    "latitude": 46.5971623,
-    "longitude": 24.3740295
+    "geo_long": 24.6859225
   },
   {
     "id": "ArekTV.id",
@@ -2235,9 +1917,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -2.4833826,
-    "geo_long": 117.8902853,
-    "latitude": 39.2897805,
-    "longitude": 40.396817
+    "geo_long": 117.8902853
   },
   {
     "id": "ArezoTV.af@SD",
@@ -2249,9 +1929,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 50.8633666,
-    "geo_long": 4.3728593,
-    "latitude": 50.8633666,
-    "longitude": 4.3728593
+    "geo_long": 4.3728593
   },
   {
     "id": "ArgentinisimaSatelital.ar",
@@ -2263,9 +1941,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -34.9964963,
-    "geo_long": -64.9672817,
-    "latitude": -34.9964963,
-    "longitude": -64.9672817
+    "geo_long": -64.9672817
   },
   {
     "id": "ArgesTV.ro",
@@ -2277,9 +1953,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 45.9852129,
-    "geo_long": 24.6859225,
-    "latitude": 44.9939764,
-    "longitude": 24.8488685
+    "geo_long": 24.6859225
   },
   {
     "id": "ArirangRadio.kr",
@@ -2291,9 +1965,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 36.638392,
-    "geo_long": 127.6961188,
-    "latitude": 36.638392,
-    "longitude": 127.6961188
+    "geo_long": 127.6961188
   },
   {
     "id": "ArirangTV.kr",
@@ -2305,9 +1977,7 @@
     "categories": "General;News",
     "type": "tv",
     "geo_lat": 36.638392,
-    "geo_long": 127.6961188,
-    "latitude": 19.423614,
-    "longitude": -99.1661107
+    "geo_long": 127.6961188
   },
   {
     "id": "ArkadagTV.tm",
@@ -2319,9 +1989,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 38.0696871,
-    "geo_long": 58.0677654,
-    "latitude": 38.0696871,
-    "longitude": 58.0677654
+    "geo_long": 58.0677654
   },
   {
     "id": "Armenia1.am@SD",
@@ -2333,9 +2001,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 40.1876953,
-    "geo_long": 44.5242697,
-    "latitude": 40.1876953,
-    "longitude": 44.5242697
+    "geo_long": 44.5242697
   },
   {
     "id": "Armenia2.am@SD",
@@ -2347,9 +2013,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 4.5338237,
-    "geo_long": -75.6703332,
-    "latitude": 4.5338237,
-    "longitude": -75.6703332
+    "geo_long": -75.6703332
   },
   {
     "id": "ARTTV.gr",
@@ -2361,9 +2025,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 38.9953683,
-    "geo_long": 21.9877132,
-    "latitude": 41.7084124,
-    "longitude": 44.7515329
+    "geo_long": 21.9877132
   },
   {
     "id": "ARTNTV.us",
@@ -2375,23 +2037,19 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.7837304,
-    "geo_long": -100.445882,
-    "latitude": 36.2048,
-    "longitude": 138.2529
+    "geo_long": -100.445882
   },
   {
     "id": "Asgabat.tm",
     "name": "Aşgabat (406p) [Not 24/7]",
     "url": "https://alpha.tv.online.tm/hls/ch006.m3u8",
     "logo": "https://i.imgur.com/EzjR1vo.png",
-    "country": "Unknown",
-    "city": "Agabat 406p Not 247",
+    "country": "Turkmenistan",
+    "city": "Ashgabat",
     "categories": "General",
     "type": "tv",
     "geo_lat": 37.9404648,
-    "geo_long": 58.3823487,
-    "latitude": 37.9601,
-    "longitude": 58.3261
+    "geo_long": 58.3823487
   },
   {
     "id": "AssenTV.nl",
@@ -2403,9 +2061,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 52.2434979,
-    "geo_long": 5.6343227,
-    "latitude": 52.997225,
-    "longitude": 6.5506458
+    "geo_long": 5.6343227
   },
   {
     "id": "KBSVDT1.us",
@@ -2417,23 +2073,19 @@
     "categories": "General;Religious",
     "type": "tv",
     "geo_lat": 39.7837304,
-    "geo_long": -100.445882,
-    "latitude": 35.485,
-    "longitude": 44.215
+    "geo_long": -100.445882
   },
   {
     "id": "AstroVaanavil.my@SD",
     "name": "Astro Vaanavil",
     "url": "https://live20.bozztv.com/akamaissh101/ssh101/sungo543/playlist.m3u8",
     "logo": "https://upload.wikimedia.org/wikipedia/en/d/d5/Astro_Vaanavil_2020.png",
-    "country": "Unknown",
-    "city": "Astro Vaanavil",
+    "country": "Malaysia",
+    "city": "Kuala Lumpur",
     "categories": "General",
     "type": "tv",
     "geo_lat": 3.1526589,
-    "geo_long": 101.7022205,
-    "latitude": 4.2105,
-    "longitude": 101.9758
+    "geo_long": 101.7022205
   },
   {
     "id": "AT5.nl",
@@ -2445,23 +2097,19 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 52.2434979,
-    "geo_long": 5.6343227,
-    "latitude": 26.1668651,
-    "longitude": 78.1778261
+    "geo_long": 5.6343227
   },
   {
     "id": "ATBLaPaz.bo",
     "name": "ATB La Paz (614p) [Not 24/7]",
     "url": "http://186.121.206.197/live/daniel/index.m3u8",
     "logo": "https://i.imgur.com/E243X2x.png",
-    "country": "Unknown",
-    "city": "ATB La Paz 614p Not 247",
+    "country": "Bolivia",
+    "city": "La Paz",
     "categories": "General",
     "type": "tv",
     "geo_lat": -16.4955455,
-    "geo_long": -68.1336229,
-    "latitude": -17.0568696,
-    "longitude": -64.9912286
+    "geo_long": -68.1336229
   },
   {
     "id": "AtinkaTV.gh@SD",
@@ -2473,9 +2121,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 43.4287726,
-    "geo_long": 76.9034716,
-    "latitude": 43.4287726,
-    "longitude": 76.9034716
+    "geo_long": 76.9034716
   },
   {
     "id": "AtlantaChannel.us@SD",
@@ -2487,9 +2133,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 33.8937162,
-    "geo_long": -84.4602403,
-    "latitude": 33.8937162,
-    "longitude": -84.4602403
+    "geo_long": -84.4602403
   },
   {
     "id": "ATNNational.af@SD",
@@ -2501,9 +2145,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 14.4656556,
-    "geo_long": 120.9949715,
-    "latitude": 14.4656556,
-    "longitude": 120.9949715
+    "geo_long": 120.9949715
   },
   {
     "id": "AtrakTV.ir",
@@ -2515,9 +2157,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 32.6475314,
-    "geo_long": 54.5643516,
-    "latitude": 38.1122225,
-    "longitude": 55.0647047
+    "geo_long": 54.5643516
   },
   {
     "id": "AtticaTV.gr",
@@ -2529,9 +2169,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 38.9953683,
-    "geo_long": 21.9877132,
-    "latitude": 37.9753513,
-    "longitude": 23.7363656
+    "geo_long": 21.9877132
   },
   {
     "id": "AndorraTV.ad",
@@ -2543,9 +2181,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 42.5407167,
-    "geo_long": 1.5732033,
-    "latitude": 42.5407167,
-    "longitude": 1.5732033
+    "geo_long": 1.5732033
   },
   {
     "id": "ATV.at",
@@ -2557,9 +2193,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 47.59397,
-    "geo_long": 14.12456,
-    "latitude": 47.59397,
-    "longitude": 14.12456
+    "geo_long": 14.12456
   },
   {
     "id": "ATV.gn",
@@ -2571,9 +2205,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 10.7226226,
-    "geo_long": -10.7083587,
-    "latitude": 10.7226226,
-    "longitude": -10.7083587
+    "geo_long": -10.7083587
   },
   {
     "id": "ATV.pe",
@@ -2585,9 +2217,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -9.19,
-    "geo_long": -75.0152,
-    "latitude": -9.19,
-    "longitude": -75.0152
+    "geo_long": -75.0152
   },
   {
     "id": "ATV.tr",
@@ -2599,9 +2229,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 38.9637,
-    "geo_long": 35.2433,
-    "latitude": 38.9637,
-    "longitude": 35.2433
+    "geo_long": 35.2433
   },
   {
     "id": "ATV2.at@HD",
@@ -2613,9 +2241,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 47.59397,
-    "geo_long": 14.12456,
-    "latitude": 47.59397,
-    "longitude": 14.12456
+    "geo_long": 14.12456
   },
   {
     "id": "ATVAlanya.tr",
@@ -2627,9 +2253,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 38.9637,
-    "geo_long": 35.2433,
-    "latitude": 38.9637,
-    "longitude": 35.2433
+    "geo_long": 35.2433
   },
   {
     "id": "ATVSur.pe",
@@ -2641,9 +2265,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -9.19,
-    "geo_long": -75.0152,
-    "latitude": -9.19,
-    "longitude": -75.0152
+    "geo_long": -75.0152
   },
   {
     "id": "Atyray.kz",
@@ -2655,9 +2277,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 48.1012954,
-    "geo_long": 66.7780818,
-    "latitude": 47.1072,
-    "longitude": 51.9153
+    "geo_long": 66.7780818
   },
   {
     "id": "AugsburgTV.de",
@@ -2669,23 +2289,19 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 51.1638175,
-    "geo_long": 10.4478313,
-    "latitude": 48.3690341,
-    "longitude": 10.8979522
+    "geo_long": 10.4478313
   },
   {
     "id": "aurLifeHD.pk",
     "name": "aurLife HD (614p)",
     "url": "http://124.109.47.101/hls/stream1.m3u8",
     "logo": "https://i.imgur.com/GfWLn3O.jpg",
-    "country": "Unknown",
-    "city": "aurLife HD 614p",
+    "country": "Pakistan",
+    "city": "Karachi",
     "categories": "General",
     "type": "tv",
     "geo_lat": 24.8546842,
-    "geo_long": 67.0207055,
-    "latitude": 30.3308401,
-    "longitude": 71.247499
+    "geo_long": 67.0207055
   },
   {
     "id": "AuroraTV.us",
@@ -2697,9 +2313,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.7837304,
-    "geo_long": -100.445882,
-    "latitude": 15.759531,
-    "longitude": 121.5671028
+    "geo_long": -100.445882
   },
   {
     "id": "AustralTV.ec",
@@ -2711,9 +2325,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -1.3397668,
-    "geo_long": -79.3666965,
-    "latitude": -34.4567098,
-    "longitude": -58.8588653
+    "geo_long": -79.3666965
   },
   {
     "id": "AutenticaTelevision.pe",
@@ -2725,9 +2337,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -6.8699697,
-    "geo_long": -75.0458515,
-    "latitude": -6.8699697,
-    "longitude": -75.0458515
+    "geo_long": -75.0458515
   },
   {
     "id": "Avers.ua",
@@ -2739,9 +2349,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 49.4871968,
-    "geo_long": 31.2718321,
-    "latitude": 46.4446229,
-    "longitude": 9.5329049
+    "geo_long": 31.2718321
   },
   {
     "id": "AWE.us",
@@ -2753,9 +2361,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.7837304,
-    "geo_long": -100.445882,
-    "latitude": 40.7128,
-    "longitude": -74.006
+    "geo_long": -100.445882
   },
   {
     "id": "AWEEncore.us",
@@ -2767,9 +2373,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.7837304,
-    "geo_long": -100.445882,
-    "latitude": 40.7128,
-    "longitude": -74.006
+    "geo_long": -100.445882
   },
   {
     "id": "AysenTV.cl",
@@ -2781,9 +2385,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -31.7613365,
-    "geo_long": -71.3187697,
-    "latitude": -46.1434629,
-    "longitude": -74.2127886
+    "geo_long": -71.3187697
   },
   {
     "id": "AzStarTV.ca",
@@ -2795,9 +2397,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 61.0666922,
-    "geo_long": -107.991707,
-    "latitude": 40.3755471,
-    "longitude": 49.8178625
+    "geo_long": -107.991707
   },
   {
     "id": "AzTV.az",
@@ -2809,9 +2409,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 40.3936294,
-    "geo_long": 47.7872508,
-    "latitude": 35.1864014,
-    "longitude": -113.6344671
+    "geo_long": 47.7872508
   },
   {
     "id": "AzadTV.az",
@@ -2823,9 +2421,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 40.3936294,
-    "geo_long": 47.7872508,
-    "latitude": 40.6940113,
-    "longitude": 46.5111894
+    "geo_long": 47.7872508
   },
   {
     "id": "WestAzerbaijanTV.ir",
@@ -2837,9 +2433,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 32.6475314,
-    "geo_long": 54.5643516,
-    "latitude": 37.7416484,
-    "longitude": 45.0207638
+    "geo_long": 54.5643516
   },
   {
     "id": "Azteca7.mx",
@@ -2851,37 +2445,31 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 23.6585116,
-    "geo_long": -102.0077097,
-    "latitude": 23.6585116,
-    "longitude": -102.0077097
+    "geo_long": -102.0077097
   },
   {
     "id": "AztecaGuatemala.gt",
     "name": "Azteca Guate (1080p)",
     "url": "https://ch1-tva.duin.dev/hls/stream.m3u8",
     "logo": "https://i.imgur.com/UJhQoUK.png",
-    "country": "Unknown",
-    "city": "Azteca Guate 1080p",
+    "country": "Guatemala",
+    "city": "Guatemala City",
     "categories": "General",
     "type": "tv",
     "geo_lat": 14.6416142,
-    "geo_long": -90.5132836,
-    "latitude": 15.5855545,
-    "longitude": -90.345759
+    "geo_long": -90.5132836
   },
   {
     "id": "AztecaHonduras.hn",
     "name": "Azteca Honduras [Geo-blocked]",
     "url": "https://mdstrm.com/live-stream-playlist/60b56be1000ea50835fa1e63.m3u8",
     "logo": "https://i.imgur.com/sxFh1dw.png",
-    "country": "Unknown",
-    "city": "Azteca Honduras Geo",
+    "country": "Honduras",
+    "city": "Tegucigalpa",
     "categories": "General",
     "type": "tv",
     "geo_lat": 14.1057433,
-    "geo_long": -87.2040052,
-    "latitude": 15.2572432,
-    "longitude": -86.0755145
+    "geo_long": -87.2040052
   },
   {
     "id": "AztecaUno.mx",
@@ -2893,9 +2481,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 23.6585116,
-    "geo_long": -102.0077097,
-    "latitude": 23.6585116,
-    "longitude": -102.0077097
+    "geo_long": -102.0077097
   },
   {
     "id": "AzzurraTV.it",
@@ -2907,9 +2493,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 42.6384261,
-    "geo_long": 12.674297,
-    "latitude": 44.0580563,
-    "longitude": 6.0638506
+    "geo_long": 12.674297
   },
   {
     "id": "BTV.hu",
@@ -2921,9 +2505,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 47.1817585,
-    "geo_long": 19.5060937,
-    "latitude": 47.1817585,
-    "longitude": 19.5060937
+    "geo_long": 19.5060937
   },
   {
     "id": "Badakhshon.tj",
@@ -2935,9 +2517,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 38.6281733,
-    "geo_long": 70.8156541,
-    "latitude": 37.9116,
-    "longitude": 70.5058
+    "geo_long": 70.8156541
   },
   {
     "id": "BadenTV.de",
@@ -2949,9 +2529,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 51.1638175,
-    "geo_long": 10.4478313,
-    "latitude": 48.6850065,
-    "longitude": 8.1174105
+    "geo_long": 10.4478313
   },
   {
     "id": "BadenTVSud.de",
@@ -2963,9 +2541,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 51.1638175,
-    "geo_long": 10.4478313,
-    "latitude": 48.6850065,
-    "longitude": 8.1174105
+    "geo_long": 10.4478313
   },
   {
     "id": "BaharTV.af",
@@ -2977,23 +2553,19 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 33.7680065,
-    "geo_long": 66.2385139,
-    "latitude": 36.4040024,
-    "longitude": 59.6084489
+    "geo_long": 66.2385139
   },
   {
     "id": "BahrainInternational.bh",
     "name": "Bahrain International (720p) [Not 24/7]",
     "url": "https://5c7b683162943.streamlock.net/live/ngrp:bahraininternational_all/playlist.m3u8",
     "logo": "https://i.imgur.com/t6Lmntr.png",
-    "country": "Unknown",
-    "city": "Bahrain International 720p Not",
+    "country": "Bahrain",
+    "city": "Manama",
     "categories": "General",
     "type": "tv",
     "geo_lat": 26.2235041,
-    "geo_long": 50.5822436,
-    "latitude": 46,
-    "longitude": -58
+    "geo_long": 50.5822436
   },
   {
     "id": "BahrainTV.bh",
@@ -3005,9 +2577,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 26.1551249,
-    "geo_long": 50.5344606,
-    "latitude": 26.1551249,
-    "longitude": 50.5344606
+    "geo_long": 50.5344606
   },
   {
     "id": "BajaiTV.hu",
@@ -3019,9 +2589,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 47.1817585,
-    "geo_long": 19.5060937,
-    "latitude": 46.1508016,
-    "longitude": 18.9548665
+    "geo_long": 19.5060937
   },
   {
     "id": "BalikpapanTV.id",
@@ -3033,9 +2601,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -2.4833826,
-    "geo_long": 117.8902853,
-    "latitude": -1.2398711,
-    "longitude": 116.8593379
+    "geo_long": 117.8902853
   },
   {
     "id": "BanatTV.ro",
@@ -3047,9 +2613,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 45.9852129,
-    "geo_long": 24.6859225,
-    "latitude": 45.5177463,
-    "longitude": -87.6976182
+    "geo_long": 24.6859225
   },
   {
     "id": "BandungTV.id",
@@ -3061,9 +2625,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -2.4833826,
-    "geo_long": 117.8902853,
-    "latitude": -7.0050378,
-    "longitude": 107.7420402
+    "geo_long": 117.8902853
   },
   {
     "id": "BaranTV.ir",
@@ -3075,9 +2637,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 32.6475314,
-    "geo_long": 54.5643516,
-    "latitude": 24.9208165,
-    "longitude": 76.6821985
+    "geo_long": 54.5643516
   },
   {
     "id": "BayresTV.ar",
@@ -3089,9 +2649,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -34.9964963,
-    "geo_long": -64.9672817,
-    "latitude": -34.5847936,
-    "longitude": -58.4890443
+    "geo_long": -64.9672817
   },
   {
     "id": "BBCAlba.uk",
@@ -3103,317 +2661,271 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 54.7023545,
-    "geo_long": -3.2765753,
-    "latitude": 42,
-    "longitude": -56
+    "geo_long": -3.2765753
   },
   {
     "id": "BBCFourCBeebies.uk@HD",
     "name": "BBC Four/CBeebies (1080p)",
     "url": "https://viamotionhsi.netplus.ch/live/eds/bbc4cbeebies/browser-HLS8/bbc4cbeebies.m3u8",
     "logo": "https://i0.wp.com/cleanfeed.thetvroom.com/media/2022/06/freeview-bbc-four-cbeebies-202206-001-01.png",
-    "country": "Unknown",
-    "city": "BBC FourCBeebies 1080p",
+    "country": "UK",
+    "city": "London",
     "categories": "Animation;General;Kids",
     "type": "tv",
-    "geo_lat": 51.4893335,
-    "geo_long": -0.1440551,
-    "latitude": 44,
-    "longitude": -56
+    "geo_lat": 51.5074456,
+    "geo_long": -0.1277653
   },
   {
     "id": "BBCOne.uk@ChannelIslands",
     "name": "BBC One Channel Islands (1080p) [Geo-blocked]",
     "url": "https://vs-cmaf-pushb-uk-live.akamaized.net/x=4/i=urn:bbc:pips:service:bbc_one_channel_islands/iptv_mse_v0_hevc.mpd",
     "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8b/BBC_One_logo_2021.svg/512px-BBC_One_logo_2021.svg.png",
-    "country": "Unknown",
-    "city": "BBC One Channel Islands 1080p ",
+    "country": "Jersey",
+    "city": "Saint Helier",
     "categories": "General",
     "type": "tv",
     "geo_lat": 49.1856637,
-    "geo_long": -2.1102277,
-    "latitude": 46,
-    "longitude": -56
+    "geo_long": -2.1102277
   },
   {
     "id": "BBCOne.uk@YorkshireHD",
     "name": "BBC One East (720p) [Geo-blocked]",
     "url": "https://vs-cmaf-pushb-uk-live.akamaized.net/x=4/i=urn:bbc:pips:service:bbc_one_east_yorkshire/pc_hd_abr_v2.mpd",
     "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8b/BBC_One_logo_2021.svg/512px-BBC_One_logo_2021.svg.png",
-    "country": "Unknown",
-    "city": "BBC One East 720p Geo",
+    "country": "UK",
+    "city": "Leeds",
     "categories": "General",
     "type": "tv",
     "geo_lat": 53.7974185,
-    "geo_long": -1.5437941,
-    "latitude": 48,
-    "longitude": -56
+    "geo_long": -1.5437941
   },
   {
     "id": "BBCOne.uk@EastMidlands",
     "name": "BBC One East Midlands (720p) [Geo-blocked]",
     "url": "https://vs-cmaf-pushb-uk-live.akamaized.net/x=4/i=urn:bbc:pips:service:bbc_one_east_midlands/pc_hd_abr_v2.mpd",
     "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8b/BBC_One_logo_2021.svg/512px-BBC_One_logo_2021.svg.png",
-    "country": "Unknown",
-    "city": "BBC One East Midlands 720p Geo",
+    "country": "UK",
+    "city": "Nottingham",
     "categories": "General",
     "type": "tv",
     "geo_lat": 52.9534193,
-    "geo_long": -1.1496461,
-    "latitude": 50,
-    "longitude": -56
+    "geo_long": -1.1496461
   },
   {
     "id": "BBCOne.uk@EastMidlandsHD",
     "name": "BBC One East Midlands (1080p) [Geo-blocked]",
     "url": "https://vs-cmaf-pushb-uk-live.akamaized.net/x=4/i=urn:bbc:pips:service:bbc_one_east_midlands/iptv_mse_v0_hevc.mpd",
     "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8b/BBC_One_logo_2021.svg/512px-BBC_One_logo_2021.svg.png",
-    "country": "Unknown",
-    "city": "BBC One East Midlands 1080p Ge",
+    "country": "UK",
+    "city": "Nottingham",
     "categories": "General",
     "type": "tv",
     "geo_lat": 52.9534193,
-    "geo_long": -1.1496461,
-    "latitude": 52,
-    "longitude": -56
+    "geo_long": -1.1496461
   },
   {
     "id": "BBCOne.uk@Yorkshire",
     "name": "BBC One East Yorkshire (540p) [Geo-blocked]",
     "url": "https://vs-hls-pushb-uk-live.akamaized.net/x=4/i=urn:bbc:pips:service:bbc_one_east_yorkshire/pc_hd_abr_v2.m3u8",
     "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8b/BBC_One_logo_2021.svg/512px-BBC_One_logo_2021.svg.png",
-    "country": "Unknown",
-    "city": "BBC One East Yorkshire 540p Ge",
+    "country": "UK",
+    "city": "Hull",
     "categories": "General",
     "type": "tv",
     "geo_lat": 53.7435722,
-    "geo_long": -0.3394758,
-    "latitude": 54,
-    "longitude": -56
+    "geo_long": -0.3394758
   },
   {
     "id": "BBCOne.uk@NorthEastCumbria",
     "name": "BBC One North East (720p) [Geo-blocked]",
     "url": "https://vs-cmaf-pushb-uk-live.akamaized.net/x=4/i=urn:bbc:pips:service:bbc_one_north_east/pc_hd_abr_v2.mpd",
     "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8b/BBC_One_logo_2021.svg/512px-BBC_One_logo_2021.svg.png",
-    "country": "Unknown",
-    "city": "BBC One North East 720p Geo",
+    "country": "UK",
+    "city": "Newcastle upon Tyne",
     "categories": "General",
     "type": "tv",
     "geo_lat": 54.9738474,
-    "geo_long": -1.6131572,
-    "latitude": 56,
-    "longitude": -56
+    "geo_long": -1.6131572
   },
   {
     "id": "BBCOne.uk@NorthEastCumbriaHD",
     "name": "BBC One North East (1080p) [Geo-blocked]",
     "url": "https://vs-cmaf-pushb-uk-live.akamaized.net/x=4/i=urn:bbc:pips:service:bbc_one_north_east/iptv_mse_v0_hevc.mpd",
     "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8b/BBC_One_logo_2021.svg/512px-BBC_One_logo_2021.svg.png",
-    "country": "Unknown",
-    "city": "BBC One North East 1080p Geo",
+    "country": "UK",
+    "city": "Newcastle upon Tyne",
     "categories": "General",
     "type": "tv",
     "geo_lat": 54.9738474,
-    "geo_long": -1.6131572,
-    "latitude": 58,
-    "longitude": -56
+    "geo_long": -1.6131572
   },
   {
     "id": "BBCOne.uk@NorthWest",
     "name": "BBC One North West (720p) [Geo-blocked]",
     "url": "https://vs-cmaf-pushb-uk-live.akamaized.net/x=4/i=urn:bbc:pips:service:bbc_one_north_west/pc_hd_abr_v2.mpd",
     "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8b/BBC_One_logo_2021.svg/512px-BBC_One_logo_2021.svg.png",
-    "country": "Unknown",
-    "city": "BBC One North West 720p Geo",
+    "country": "UK",
+    "city": "Manchester",
     "categories": "General",
     "type": "tv",
     "geo_lat": 53.4794892,
-    "geo_long": -2.2451148,
-    "latitude": 40,
-    "longitude": -54
+    "geo_long": -2.2451148
   },
   {
     "id": "BBCOne.uk@NorthWestHD",
     "name": "BBC One North West (1080p) [Geo-blocked]",
     "url": "https://vs-cmaf-pushb-uk-live.akamaized.net/x=4/i=urn:bbc:pips:service:bbc_one_north_west/iptv_mse_v0_hevc.mpd",
     "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8b/BBC_One_logo_2021.svg/512px-BBC_One_logo_2021.svg.png",
-    "country": "Unknown",
-    "city": "BBC One North West 1080p Geo",
+    "country": "UK",
+    "city": "Manchester",
     "categories": "General",
     "type": "tv",
     "geo_lat": 53.4794892,
-    "geo_long": -2.2451148,
-    "latitude": 42,
-    "longitude": -54
+    "geo_long": -2.2451148
   },
   {
     "id": "BBCOne.uk@NorthernIreland",
     "name": "BBC One Northern Ireland HD (720p) [Geo-blocked]",
     "url": "https://vs-cmaf-pushb-uk-live.akamaized.net/x=4/i=urn:bbc:pips:service:bbc_one_northern_ireland_hd/pc_hd_abr_v2.mpd",
     "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8b/BBC_One_logo_2021.svg/512px-BBC_One_logo_2021.svg.png",
-    "country": "Unknown",
-    "city": "BBC One Northern Ireland HD 72",
+    "country": "UK",
+    "city": "Belfast",
     "categories": "General",
     "type": "tv",
     "geo_lat": 54.5975805,
-    "geo_long": -5.9277097,
-    "latitude": 44,
-    "longitude": -54
+    "geo_long": -5.9277097
   },
   {
     "id": "BBCOne.uk@NorthernIrelandHD",
     "name": "BBC One Northern Ireland HD (1080p) [Geo-blocked]",
     "url": "https://vs-cmaf-pushb-uk-live.akamaized.net/x=4/i=urn:bbc:pips:service:bbc_one_northern_ireland_hd/iptv_mse_v0_hevc.mpd",
     "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8b/BBC_One_logo_2021.svg/512px-BBC_One_logo_2021.svg.png",
-    "country": "Unknown",
-    "city": "BBC One Northern Ireland HD 10",
+    "country": "UK",
+    "city": "Belfast",
     "categories": "General",
     "type": "tv",
     "geo_lat": 54.5975805,
-    "geo_long": -5.9277097,
-    "latitude": 46,
-    "longitude": -54
+    "geo_long": -5.9277097
   },
   {
     "id": "BBCOne.uk@Scotland",
     "name": "BBC One Scotland (540p) [Geo-blocked]",
     "url": "https://vs-hls-pushb-uk-live.akamaized.net/x=4/i=urn:bbc:pips:service:bbc_one_scotland_hd/pc_hd_abr_v2.m3u8",
     "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8b/BBC_One_logo_2021.svg/512px-BBC_One_logo_2021.svg.png",
-    "country": "Unknown",
-    "city": "BBC One Scotland 540p Geo",
+    "country": "UK",
+    "city": "Glasgow",
     "categories": "General",
     "type": "tv",
     "geo_lat": 55.861155,
-    "geo_long": -4.2501687,
-    "latitude": 48,
-    "longitude": -54
+    "geo_long": -4.2501687
   },
   {
     "id": "BBCOne.uk@ScotlandHD",
     "name": "BBC One Scotland HD (1080p) [Geo-blocked]",
     "url": "https://vs-cmaf-pushb-uk-live.akamaized.net/x=4/i=urn:bbc:pips:service:bbc_one_scotland_hd/iptv_mse_v0_hevc.mpd",
     "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8b/BBC_One_logo_2021.svg/512px-BBC_One_logo_2021.svg.png",
-    "country": "Unknown",
-    "city": "BBC One Scotland HD 1080p Geo",
+    "country": "UK",
+    "city": "Glasgow",
     "categories": "General",
     "type": "tv",
     "geo_lat": 55.861155,
-    "geo_long": -4.2501687,
-    "latitude": 50,
-    "longitude": -54
+    "geo_long": -4.2501687
   },
   {
     "id": "BBCOne.uk@South",
     "name": "BBC One South (1080p) [Geo-blocked]",
     "url": "https://vs-cmaf-pushb-uk-live.akamaized.net/x=4/i=urn:bbc:pips:service:bbc_one_south/iptv_mse_v0_hevc.mpd",
     "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8b/BBC_One_logo_2021.svg/512px-BBC_One_logo_2021.svg.png",
-    "country": "Unknown",
-    "city": "BBC One South 1080p Geo",
+    "country": "UK",
+    "city": "Southampton",
     "categories": "General",
     "type": "tv",
     "geo_lat": 50.9025349,
-    "geo_long": -1.404189,
-    "latitude": 52,
-    "longitude": -54
+    "geo_long": -1.404189
   },
   {
     "id": "BBCOne.uk@SouthEast",
     "name": "BBC One South East (1080p) [Geo-blocked]",
     "url": "https://vs-cmaf-pushb-uk-live.akamaized.net/x=4/i=urn:bbc:pips:service:bbc_one_south_east/iptv_mse_v0_hevc.mpd",
     "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8b/BBC_One_logo_2021.svg/512px-BBC_One_logo_2021.svg.png",
-    "country": "Unknown",
-    "city": "BBC One South East 1080p Geo",
+    "country": "UK",
+    "city": "Tunbridge Wells",
     "categories": "General",
     "type": "tv",
     "geo_lat": 51.1371483,
-    "geo_long": 0.2673446,
-    "latitude": 54,
-    "longitude": -54
+    "geo_long": 0.2673446
   },
   {
     "id": "BBCOne.uk@SouthWest",
     "name": "BBC One South West (1080p) [Geo-blocked]",
     "url": "https://vs-cmaf-pushb-uk-live.akamaized.net/x=4/i=urn:bbc:pips:service:bbc_one_south_west/iptv_mse_v0_hevc.mpd",
     "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8b/BBC_One_logo_2021.svg/512px-BBC_One_logo_2021.svg.png",
-    "country": "Unknown",
-    "city": "BBC One South West 1080p Geo",
+    "country": "UK",
+    "city": "Plymouth",
     "categories": "General",
     "type": "tv",
     "geo_lat": 50.3714122,
-    "geo_long": -4.1424451,
-    "latitude": 56,
-    "longitude": -54
+    "geo_long": -4.1424451
   },
   {
     "id": "BBCOne.uk@SouthWestHD",
     "name": "BBC One South West HD (720p)",
     "url": "https://stream.nexyl.uk/ee971134-115e-4418-8d1d-69dff7d4c6eb.m3u8",
     "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8b/BBC_One_logo_2021.svg/512px-BBC_One_logo_2021.svg.png",
-    "country": "Unknown",
-    "city": "BBC One South West HD 720p",
+    "country": "UK",
+    "city": "Plymouth",
     "categories": "General",
     "type": "tv",
     "geo_lat": 50.3714122,
-    "geo_long": -4.1424451,
-    "latitude": 58,
-    "longitude": -54
+    "geo_long": -4.1424451
   },
   {
     "id": "BBCOne.uk@Wales",
     "name": "BBC One Wales (1080p) [Geo-blocked]",
     "url": "https://vs-cmaf-pushb-uk-live.akamaized.net/x=4/i=urn:bbc:pips:service:bbc_one_wales_hd/iptv_mse_v0_hevc.mpd",
     "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8b/BBC_One_logo_2021.svg/512px-BBC_One_logo_2021.svg.png",
-    "country": "Unknown",
-    "city": "BBC One Wales 1080p Geo",
+    "country": "UK",
+    "city": "Cardiff",
     "categories": "General",
     "type": "tv",
     "geo_lat": 51.4816546,
-    "geo_long": -3.1791934,
-    "latitude": 40,
-    "longitude": -52
+    "geo_long": -3.1791934
   },
   {
     "id": "BBCOne.uk@West",
     "name": "BBC One West (1080p) [Geo-blocked]",
     "url": "https://vs-cmaf-pushb-uk-live.akamaized.net/x=4/i=urn:bbc:pips:service:bbc_one_west/iptv_mse_v0_hevc.mpd",
     "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8b/BBC_One_logo_2021.svg/512px-BBC_One_logo_2021.svg.png",
-    "country": "Unknown",
-    "city": "BBC One West 1080p Geo",
+    "country": "UK",
+    "city": "Bristol",
     "categories": "General",
     "type": "tv",
     "geo_lat": 51.4538022,
-    "geo_long": -2.5972985,
-    "latitude": 42,
-    "longitude": -52
+    "geo_long": -2.5972985
   },
   {
     "id": "BBCOne.uk@WestMidlands",
     "name": "BBC One West Midlands (1080p) [Geo-blocked]",
     "url": "https://vs-cmaf-pushb-uk-live.akamaized.net/x=4/i=urn:bbc:pips:service:bbc_one_west_midlands/iptv_mse_v0_hevc.mpd",
     "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8b/BBC_One_logo_2021.svg/512px-BBC_One_logo_2021.svg.png",
-    "country": "Unknown",
-    "city": "BBC One West Midlands 1080p Ge",
+    "country": "UK",
+    "city": "Birmingham",
     "categories": "General",
     "type": "tv",
     "geo_lat": 52.4796992,
-    "geo_long": -1.9026911,
-    "latitude": 44,
-    "longitude": -52
+    "geo_long": -1.9026911
   },
   {
     "id": "BBCOne.uk@YorkshireLincolnshire",
     "name": "BBC One Yorkshire & Lincolnshire (1080p)",
     "url": "http://92.114.85.72:8000/play/a0mp",
     "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8b/BBC_One_logo_2021.svg/512px-BBC_One_logo_2021.svg.png",
-    "country": "Unknown",
-    "city": "BBC One Yorkshire  Lincolnshir",
+    "country": "UK",
+    "city": "Leeds",
     "categories": "General",
     "type": "tv",
     "geo_lat": 53.7974185,
-    "geo_long": -1.5437941,
-    "latitude": 46,
-    "longitude": -52
+    "geo_long": -1.5437941
   },
   {
     "id": "BBCScotland.uk",
@@ -3425,9 +2937,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 54.7023545,
-    "geo_long": -3.2765753,
-    "latitude": 48,
-    "longitude": -52
+    "geo_long": -3.2765753
   },
   {
     "id": "BBCThree.uk",
@@ -3439,51 +2949,43 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 54.7023545,
-    "geo_long": -3.2765753,
-    "latitude": 51.8771744,
-    "longitude": -0.4183493
+    "geo_long": -3.2765753
   },
   {
     "id": "BBCThree.uk@HD",
     "name": "BBC Three HD (720p)",
     "url": "https://streamer.nexyl.uk/39290a19-b8dd-43ea-b8dc-081c37790f24.m3u8",
     "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/7/76/BBC_Three_2022.svg/512px-BBC_Three_2022.svg.png",
-    "country": "Unknown",
-    "city": "BBC Three HD 720p",
+    "country": "UK",
+    "city": "London",
     "categories": "General",
     "type": "tv",
-    "geo_lat": 51.4893335,
-    "geo_long": -0.1440551,
-    "latitude": 52,
-    "longitude": -52
+    "geo_lat": 51.5074456,
+    "geo_long": -0.1277653
   },
   {
     "id": "BBCTwo.uk@England",
     "name": "BBC Two",
     "url": "https://live20.bozztv.com/dvrfl06/astv/astv-bbctwo/index.m3u8",
     "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/BBC_Two_logo_2021.svg/512px-BBC_Two_logo_2021.svg.png",
-    "country": "Unknown",
-    "city": "BBC Two",
+    "country": "UK",
+    "city": "London",
     "categories": "General",
     "type": "tv",
-    "geo_lat": 51.4893335,
-    "geo_long": -0.1440551,
-    "latitude": 54,
-    "longitude": -52
+    "geo_lat": 51.5074456,
+    "geo_long": -0.1277653
   },
   {
     "id": "BBCTwo.uk@HD",
     "name": "BBC Two HD (720p)",
     "url": "https://streamer.nexyl.uk/69ef899e-8ca9-4537-9f1a-fe8b4216afbb.m3u8",
     "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/BBC_Two_logo_2021.svg/512px-BBC_Two_logo_2021.svg.png",
-    "country": "Unknown",
-    "city": "BBC Two HD 720p",
+    "country": "UK",
+    "city": "London",
     "categories": "General",
     "type": "tv",
-    "geo_lat": 51.4893335,
-    "geo_long": -0.1440551,
-    "latitude": 56,
-    "longitude": -52
+    "geo_lat": 51.5074456,
+    "geo_long": -0.1277653
   },
   {
     "id": "BBCTwo.uk@NorthernIreland",
@@ -3495,37 +2997,31 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 54.8587151,
-    "geo_long": -6.3281053,
-    "latitude": 58,
-    "longitude": -52
+    "geo_long": -6.3281053
   },
   {
     "id": "BBCTwo.uk@NorthernIrelandHD",
     "name": "BBC Two Northern Ireland HD (1080p) [Geo-blocked]",
     "url": "https://vs-cmaf-pushb-uk-live.akamaized.net/x=4/i=urn:bbc:pips:service:bbc_two_northern_ireland_hd/iptv_mse_v0_hevc.mpd",
     "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/BBC_Two_logo_2021.svg/512px-BBC_Two_logo_2021.svg.png",
-    "country": "Unknown",
-    "city": "BBC Two Northern Ireland HD 10",
+    "country": "UK",
+    "city": "Belfast",
     "categories": "General",
     "type": "tv",
     "geo_lat": 54.5975805,
-    "geo_long": -5.9277097,
-    "latitude": 40,
-    "longitude": -50
+    "geo_long": -5.9277097
   },
   {
     "id": "BBCTwo.uk@Wales",
     "name": "BBC Two Wales (1080p) [Geo-blocked]",
     "url": "https://vs-cmaf-pushb-uk-live.akamaized.net/x=4/i=urn:bbc:pips:service:bbc_two_wales_digital/iptv_mse_v0_hevc.mpd",
     "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/BBC_Two_logo_2021.svg/512px-BBC_Two_logo_2021.svg.png",
-    "country": "Unknown",
-    "city": "BBC Two Wales 1080p Geo",
+    "country": "UK",
+    "city": "Cardiff",
     "categories": "General",
     "type": "tv",
     "geo_lat": 51.4816546,
-    "geo_long": -3.1791934,
-    "latitude": 42,
-    "longitude": -50
+    "geo_long": -3.1791934
   },
   {
     "id": "BBCUHD1.uk",
@@ -3537,9 +3033,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 54.7023545,
-    "geo_long": -3.2765753,
-    "latitude": 44,
-    "longitude": -50
+    "geo_long": -3.2765753
   },
   {
     "id": "BBCUHD2.uk",
@@ -3551,9 +3045,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 54.7023545,
-    "geo_long": -3.2765753,
-    "latitude": 46,
-    "longitude": -50
+    "geo_long": -3.2765753
   },
   {
     "id": "BBCUHD3.uk",
@@ -3565,9 +3057,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 54.7023545,
-    "geo_long": -3.2765753,
-    "latitude": 48,
-    "longitude": -50
+    "geo_long": -3.2765753
   },
   {
     "id": "BBCUHD4.uk",
@@ -3579,9 +3069,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 54.7023545,
-    "geo_long": -3.2765753,
-    "latitude": 50,
-    "longitude": -50
+    "geo_long": -3.2765753
   },
   {
     "id": "BBCUHD5.uk",
@@ -3593,9 +3081,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 54.7023545,
-    "geo_long": -3.2765753,
-    "latitude": 52,
-    "longitude": -50
+    "geo_long": -3.2765753
   },
   {
     "id": "BCNGospelTV.es",
@@ -3607,23 +3093,19 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.3260685,
-    "geo_long": -4.8379791,
-    "latitude": 54,
-    "longitude": -50
+    "geo_long": -4.8379791
   },
   {
     "id": "BCSStarCrossTV.ng@SD",
     "name": "BCS StarCross TV (576p)",
     "url": "https://viewmedia7219.bozztv.com/wmedia/viewmedia100/web_001/Stream/playlist.m3u8",
     "logo": "https://i.imgur.com/VKv1Y6p.png",
-    "country": "Unknown",
-    "city": "BCS StarCross",
+    "country": "Nigeria",
+    "city": "Lagos",
     "categories": "General",
     "type": "tv",
     "geo_lat": 6.4550575,
-    "geo_long": 3.3941795,
-    "latitude": 56,
-    "longitude": -50
+    "geo_long": 3.3941795
   },
   {
     "id": "BebetoTV.do@SD",
@@ -3635,9 +3117,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -31.4439515,
-    "geo_long": -53.1026637,
-    "latitude": -31.4439515,
-    "longitude": -53.1026637
+    "geo_long": -53.1026637
   },
   {
     "id": "BemTV.br",
@@ -3649,9 +3129,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -10.3333333,
-    "geo_long": -53.2,
-    "latitude": 32.4025588,
-    "longitude": -6.3157661
+    "geo_long": -53.2
   },
   {
     "id": "BerenteTV.hu",
@@ -3663,9 +3141,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 47.1817585,
-    "geo_long": 19.5060937,
-    "latitude": 48.2318559,
-    "longitude": 20.6645424
+    "geo_long": 19.5060937
   },
   {
     "id": "BergamoTV.it@SD",
@@ -3677,9 +3153,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 45.7566557,
-    "geo_long": 9.7542192,
-    "latitude": 45.7566557,
-    "longitude": 9.7542192
+    "geo_long": 9.7542192
   },
   {
     "id": "BFMAlsace.fr",
@@ -3691,9 +3165,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 46.603354,
-    "geo_long": 1.8883335,
-    "latitude": 46,
-    "longitude": -48
+    "geo_long": 1.8883335
   },
   {
     "id": "BHT1.ba",
@@ -3705,9 +3177,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 44.3053476,
-    "geo_long": 17.5961467,
-    "latitude": 48,
-    "longitude": -48
+    "geo_long": 17.5961467
   },
   {
     "id": "Binge.us",
@@ -3719,9 +3189,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.7837304,
-    "geo_long": -100.445882,
-    "latitude": -10.8897191,
-    "longitude": 14.3543887
+    "geo_long": -100.445882
   },
   {
     "id": "BinhPhuocTV1.vn",
@@ -3733,9 +3201,7 @@
     "categories": "General;News",
     "type": "tv",
     "geo_lat": 15.9266657,
-    "geo_long": 107.9650855,
-    "latitude": 11.8000377,
-    "longitude": 106.9151381
+    "geo_long": 107.9650855
   },
   {
     "id": "TVStorbyen.dk",
@@ -3747,9 +3213,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 55.670249,
-    "geo_long": 10.3333283,
-    "latitude": 46.1504888,
-    "longitude": 12.3311006
+    "geo_long": 10.3333283
   },
   {
     "id": "BlackSeaTV.ua",
@@ -3761,9 +3225,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 49.4871968,
-    "geo_long": 31.2718321,
-    "latitude": 41.0023855,
-    "longitude": 39.6904592
+    "geo_long": 31.2718321
   },
   {
     "id": "BATV.us",
@@ -3775,9 +3237,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.7837304,
-    "geo_long": -100.445882,
-    "latitude": 41.8094109,
-    "longitude": -72.7252635
+    "geo_long": -100.445882
   },
   {
     "id": "BlueSkyTV.gr",
@@ -3789,9 +3249,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 38.9953683,
-    "geo_long": 21.9877132,
-    "latitude": 40.2998886,
-    "longitude": -103.8042263
+    "geo_long": 21.9877132
   },
   {
     "id": "BMCHDTV.us",
@@ -3803,9 +3261,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.7837304,
-    "geo_long": -100.445882,
-    "latitude": 38.436561,
-    "longitude": 27.2550648
+    "geo_long": -100.445882
   },
   {
     "id": "BocaChicaTV.do@SD",
@@ -3817,9 +3273,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 18.4570748,
-    "geo_long": -69.61487,
-    "latitude": 18.4570748,
-    "longitude": -69.61487
+    "geo_long": -69.61487
   },
   {
     "id": "BoishakhiTV.bd@SD",
@@ -3831,23 +3285,19 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 1.3094303,
-    "geo_long": 103.8544843,
-    "latitude": 1.3094303,
-    "longitude": 103.8544843
+    "geo_long": 103.8544843
   },
   {
     "id": "Bolivision.bo",
     "name": "Bolivisión LPZ (720p)",
     "url": "https://alba-bo-bolivision-bolivision.stream.mediatiquestream.com/index.m3u8",
     "logo": "https://i.imgur.com/U98Z5zn.png",
-    "country": "Unknown",
-    "city": "Bolivisin LPZ 720p",
+    "country": "Bolivia",
+    "city": "La Paz",
     "categories": "General",
     "type": "tv",
     "geo_lat": -16.4955455,
-    "geo_long": -68.1336229,
-    "latitude": 48,
-    "longitude": -46
+    "geo_long": -68.1336229
   },
   {
     "id": "CVCPublic.us",
@@ -3859,9 +3309,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.7837304,
-    "geo_long": -100.445882,
-    "latitude": 50,
-    "longitude": -46
+    "geo_long": -100.445882
   },
   {
     "id": "BrionnaisTV.fr",
@@ -3873,9 +3321,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 46.603354,
-    "geo_long": 1.8883335,
-    "latitude": 46.2632756,
-    "longitude": 4.0898917
+    "geo_long": 1.8883335
   },
   {
     "id": "BrunoMasiTV.py",
@@ -3887,9 +3333,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -23.3165935,
-    "geo_long": -58.1693445,
-    "latitude": 45.107794,
-    "longitude": 11.4857111
+    "geo_long": -58.1693445
   },
   {
     "id": "BTNTV.rw",
@@ -3901,9 +3345,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -1.9646631,
-    "geo_long": 30.0644358,
-    "latitude": 27.549511,
-    "longitude": 90.5119273
+    "geo_long": 30.0644358
   },
   {
     "id": "BudapestEuropaTelevizio.hu",
@@ -3915,9 +3357,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 47.1817585,
-    "geo_long": 19.5060937,
-    "latitude": 58,
-    "longitude": -46
+    "geo_long": 19.5060937
   },
   {
     "id": "BukeddeTV1.ug",
@@ -3929,9 +3369,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 1.5333554,
-    "geo_long": 32.2166578,
-    "latitude": 0.2858473,
-    "longitude": 32.5768889
+    "geo_long": 32.2166578
   },
   {
     "id": "BukeddeTV2.ug",
@@ -3943,9 +3381,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 1.5333554,
-    "geo_long": 32.2166578,
-    "latitude": 0.2858473,
-    "longitude": 32.5768889
+    "geo_long": 32.2166578
   },
   {
     "id": "CanalVisionDorada.co",
@@ -3957,9 +3393,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 4.099917,
-    "geo_long": -72.9088133,
-    "latitude": 44,
-    "longitude": -44
+    "geo_long": -72.9088133
   },
   {
     "id": "BungoTV.id",
@@ -3971,9 +3405,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -2.4833826,
-    "geo_long": 117.8902853,
-    "latitude": -7.44,
-    "longitude": 15.386667
+    "geo_long": 117.8902853
   },
   {
     "id": "TheBurbankChannel.us",
@@ -3985,9 +3417,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.7837304,
-    "geo_long": -100.445882,
-    "latitude": 48,
-    "longitude": -44
+    "geo_long": -100.445882
   },
   {
     "id": "BurrianaTeVe.es",
@@ -3999,9 +3429,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.3260685,
-    "geo_long": -4.8379791,
-    "latitude": 39.8876912,
-    "longitude": -0.0846321
+    "geo_long": -4.8379791
   },
   {
     "id": "BXInform.us",
@@ -4013,9 +3441,7 @@
     "categories": "General;News",
     "type": "tv",
     "geo_lat": 39.7837304,
-    "geo_long": -100.445882,
-    "latitude": 52,
-    "longitude": -44
+    "geo_long": -100.445882
   },
   {
     "id": "BXInspire.us",
@@ -4027,9 +3453,7 @@
     "categories": "General;Religious",
     "type": "tv",
     "geo_lat": 39.7837304,
-    "geo_long": -100.445882,
-    "latitude": 54,
-    "longitude": -44
+    "geo_long": -100.445882
   },
   {
     "id": "BXOmni.us",
@@ -4041,9 +3465,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.7837304,
-    "geo_long": -100.445882,
-    "latitude": 56,
-    "longitude": -44
+    "geo_long": -100.445882
   },
   {
     "id": "C1.mn",
@@ -4055,9 +3477,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 46.8250388,
-    "geo_long": 103.8499736,
-    "latitude": 58,
-    "longitude": -44
+    "geo_long": 103.8499736
   },
   {
     "id": "C31Melbourne.au",
@@ -4069,9 +3489,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -24.7761086,
-    "geo_long": 134.755,
-    "latitude": 40,
-    "longitude": -42
+    "geo_long": 134.755
   },
   {
     "id": "CajamarcaTV.pe",
@@ -4083,9 +3501,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -6.8699697,
-    "geo_long": -75.0458515,
-    "latitude": -6.25,
-    "longitude": -78.833333
+    "geo_long": -75.0458515
   },
   {
     "id": "CaliforniaMediosTV.mx",
@@ -4097,9 +3513,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 23.6585116,
-    "geo_long": -102.0077097,
-    "latitude": 10.4813744,
-    "longitude": -66.8618606
+    "geo_long": -102.0077097
   },
   {
     "id": "CAM10TV.cm@SD",
@@ -4111,9 +3525,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -22.8048247,
-    "geo_long": -46.9156808,
-    "latitude": -22.8048247,
-    "longitude": -46.9156808
+    "geo_long": -46.9156808
   },
   {
     "id": "CanaTVDigital.do@SD",
@@ -4125,9 +3537,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 35.000074,
-    "geo_long": 104.999927,
-    "latitude": 29.5024686,
-    "longitude": 106.5295857
+    "geo_long": 104.999927
   },
   {
     "id": "Canaf54TV.uk@SD",
@@ -4139,9 +3549,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 50,
-    "geo_long": -42,
-    "latitude": 50,
-    "longitude": -42
+    "geo_long": -42
   },
   {
     "id": "Canal1.co",
@@ -4153,9 +3561,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 4.099917,
-    "geo_long": -72.9088133,
-    "latitude": 52,
-    "longitude": -42
+    "geo_long": -72.9088133
   },
   {
     "id": "Canal1.cr",
@@ -4167,9 +3573,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 54,
-    "geo_long": -42,
-    "latitude": 54,
-    "longitude": -42
+    "geo_long": -42
   },
   {
     "id": "Canal2.sv",
@@ -4181,9 +3585,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 13.8000382,
-    "geo_long": -88.9140683,
-    "latitude": 56,
-    "longitude": -42
+    "geo_long": -88.9140683
   },
   {
     "id": "Canal2AlpavisionNeiva.co",
@@ -4195,9 +3597,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 4.099917,
-    "geo_long": -72.9088133,
-    "latitude": 58,
-    "longitude": -42
+    "geo_long": -72.9088133
   },
   {
     "id": "Canal2deUshuaia.ar",
@@ -4209,23 +3609,19 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -34.9964963,
-    "geo_long": -64.9672817,
-    "latitude": 40,
-    "longitude": -40
+    "geo_long": -64.9672817
   },
   {
     "id": "Canal2International.cm",
     "name": "Canal 2 International",
     "url": "http://69.64.57.208/canal2international/playlist.m3u8",
     "logo": "https://i.imgur.com/BzA2z7m.png",
-    "country": "Cameroon",
+    "country": "Unknown",
     "city": "Canal 2 International",
     "categories": "General",
     "type": "tv",
     "geo_lat": 4.6125522,
-    "geo_long": 13.1535811,
-    "latitude": 0,
-    "longitude": 0
+    "geo_long": 13.1535811
   },
   {
     "id": "Canal3TVBiar.es",
@@ -4237,9 +3633,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.3260685,
-    "geo_long": -4.8379791,
-    "latitude": 44,
-    "longitude": -40
+    "geo_long": -4.8379791
   },
   {
     "id": "Canal4.cr",
@@ -4251,9 +3645,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 46,
-    "geo_long": -40,
-    "latitude": 46,
-    "longitude": -40
+    "geo_long": -40
   },
   {
     "id": "Canal4Catalunya.es",
@@ -4265,9 +3657,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.3260685,
-    "geo_long": -4.8379791,
-    "latitude": 48,
-    "longitude": -40
+    "geo_long": -4.8379791
   },
   {
     "id": "Canal4Mallorca.es",
@@ -4279,23 +3669,19 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.3260685,
-    "geo_long": -4.8379791,
-    "latitude": 50,
-    "longitude": -40
+    "geo_long": -4.8379791
   },
   {
     "id": "Canal4RD.do",
     "name": "Canal 4 RD (1080p)",
     "url": "https://protvradiostream.com:1936/canal4rd-1/ngrp:canal4rd-1_all/playlist.m3u8",
     "logo": "https://i.imgur.com/eiqpffH.png",
-    "country": "Unknown",
-    "city": "Canal 4 RD 1080p",
+    "country": "Dominican Republic",
+    "city": "Santo Domingo",
     "categories": "General",
     "type": "tv",
     "geo_lat": 18.4801972,
-    "geo_long": -69.942111,
-    "latitude": 52,
-    "longitude": -40
+    "geo_long": -69.942111
   },
   {
     "id": "Canal6.cr",
@@ -4307,9 +3693,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 54,
-    "geo_long": -40,
-    "latitude": 54,
-    "longitude": -40
+    "geo_long": -40
   },
   {
     "id": "Canal6.sv",
@@ -4321,9 +3705,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 13.8000382,
-    "geo_long": -88.9140683,
-    "latitude": 56,
-    "longitude": -40
+    "geo_long": -88.9140683
   },
   {
     "id": "MultimediosCDMX.mx",
@@ -4335,9 +3717,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 23.6585116,
-    "geo_long": -102.0077097,
-    "latitude": 19.4319694,
-    "longitude": -99.1486805
+    "geo_long": -102.0077097
   },
   {
     "id": "Canal7Neuquen.ar",
@@ -4349,9 +3729,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -34.9964963,
-    "geo_long": -64.9672817,
-    "latitude": 40,
-    "longitude": -38
+    "geo_long": -64.9672817
   },
   {
     "id": "Canal8.cr",
@@ -4363,9 +3741,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 42,
-    "geo_long": -38,
-    "latitude": 42,
-    "longitude": -38
+    "geo_long": -38
   },
   {
     "id": "Canal8Catacaos.pe",
@@ -4377,9 +3753,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -6.8699697,
-    "geo_long": -75.0458515,
-    "latitude": 44,
-    "longitude": -38
+    "geo_long": -75.0458515
   },
   {
     "id": "Canal8TVPlus.co",
@@ -4391,9 +3765,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 4.099917,
-    "geo_long": -72.9088133,
-    "latitude": 40.6533411,
-    "longitude": -73.438291
+    "geo_long": -72.9088133
   },
   {
     "id": "Canal9.cr",
@@ -4405,9 +3777,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 48,
-    "geo_long": -38,
-    "latitude": 48,
-    "longitude": -38
+    "geo_long": -38
   },
   {
     "id": "BarbeTV.gt",
@@ -4419,9 +3789,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 42.8705138,
-    "geo_long": -0.0029114,
-    "latitude": 42.8705138,
-    "longitude": -0.0029114
+    "geo_long": -0.0029114
   },
   {
     "id": "Canal9Resistencia.ar",
@@ -4433,9 +3801,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -34.9964963,
-    "geo_long": -64.9672817,
-    "latitude": 52,
-    "longitude": -38
+    "geo_long": -64.9672817
   },
   {
     "id": "XHTTGTDT.mx",
@@ -4447,9 +3813,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 23.6585116,
-    "geo_long": -102.0077097,
-    "latitude": 54,
-    "longitude": -38
+    "geo_long": -102.0077097
   },
   {
     "id": "Canal10SOLTV.co",
@@ -4461,9 +3825,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 4.099917,
-    "geo_long": -72.9088133,
-    "latitude": 46.6955258,
-    "longitude": 11.8554609
+    "geo_long": -72.9088133
   },
   {
     "id": "Canal11.cr",
@@ -4475,9 +3837,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 58,
-    "geo_long": -38,
-    "latitude": 58,
-    "longitude": -38
+    "geo_long": -38
   },
   {
     "id": "Canal11TuTV.sv",
@@ -4489,9 +3849,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 13.8000382,
-    "geo_long": -88.9140683,
-    "latitude": 46.6989055,
-    "longitude": 11.8584539
+    "geo_long": -88.9140683
   },
   {
     "id": "Canal12.sv",
@@ -4503,23 +3861,19 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 13.8000382,
-    "geo_long": -88.9140683,
-    "latitude": 42,
-    "longitude": -36
+    "geo_long": -88.9140683
   },
   {
     "id": "Canal13Esquipulas.gt",
     "name": "Canal 13 Esquipulas (720p)",
     "url": "https://tv91.hostingnuclear.com:19360/intercable/intercable.m3u8",
     "logo": "https://i.imgur.com/INKZvlN.png",
-    "country": "Unknown",
-    "city": "Canal 13 Esquipulas 720p",
+    "country": "Guatemala",
+    "city": "Esquipulas",
     "categories": "General",
     "type": "tv",
     "geo_lat": 14.6308869,
-    "geo_long": -89.2552563,
-    "latitude": 44,
-    "longitude": -36
+    "geo_long": -89.2552563
   },
   {
     "id": "Canal20.gt",
@@ -4531,9 +3885,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 46,
-    "geo_long": -36,
-    "latitude": 46,
-    "longitude": -36
+    "geo_long": -36
   },
   {
     "id": "Canal21Tachira.ve",
@@ -4545,23 +3897,19 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 8.0018709,
-    "geo_long": -66.1109318,
-    "latitude": 48,
-    "longitude": -36
+    "geo_long": -66.1109318
   },
   {
     "id": "Canal25.do@SD",
     "name": "Canal 25 (1080p) [Not 24/7]",
     "url": "https://live20.bozztv.com/akamaissh101/ssh101/canal25stgo/chunks.m3u8",
     "logo": "https://i.imgur.com/lmWu73V.png",
-    "country": "Unknown",
-    "city": "Canal 25 1080p Not 247",
+    "country": "Dominican Republic",
+    "city": "Santo Domingo",
     "categories": "General",
     "type": "tv",
     "geo_lat": 18.4801972,
-    "geo_long": -69.942111,
-    "latitude": 50,
-    "longitude": -36
+    "geo_long": -69.942111
   },
   {
     "id": "Canal32.fr",
@@ -4573,9 +3921,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 46.603354,
-    "geo_long": 1.8883335,
-    "latitude": 52,
-    "longitude": -36
+    "geo_long": 1.8883335
   },
   {
     "id": "Canal33Tijuana.mx",
@@ -4587,9 +3933,7 @@
     "categories": "General;News",
     "type": "tv",
     "geo_lat": 23.6585116,
-    "geo_long": -102.0077097,
-    "latitude": 54,
-    "longitude": -36
+    "geo_long": -102.0077097
   },
   {
     "id": "Canal34SanJuan.ar",
@@ -4601,9 +3945,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -34.9964963,
-    "geo_long": -64.9672817,
-    "latitude": 56,
-    "longitude": -36
+    "geo_long": -64.9672817
   },
   {
     "id": "XHIJTDT.mx",
@@ -4615,9 +3957,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 23.6585116,
-    "geo_long": -102.0077097,
-    "latitude": 58,
-    "longitude": -36
+    "geo_long": -102.0077097
   },
   {
     "id": "Canal55TelemoriscoTV.co",
@@ -4629,9 +3969,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 4.099917,
-    "geo_long": -72.9088133,
-    "latitude": 40,
-    "longitude": -34
+    "geo_long": -72.9088133
   },
   {
     "id": "CanalAmericaTV.do@SD",
@@ -4643,9 +3981,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 41.6739102,
-    "geo_long": -99.4589949,
-    "latitude": 41.6739102,
-    "longitude": -99.4589949
+    "geo_long": -99.4589949
   },
   {
     "id": "CanalCatorce.do",
@@ -4657,9 +3993,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 44,
-    "geo_long": -34,
-    "latitude": 44,
-    "longitude": -34
+    "geo_long": -34
   },
   {
     "id": "CanalDTV.do",
@@ -4670,10 +4004,8 @@
     "city": "Canal D",
     "categories": "General",
     "type": "tv",
-    "geo_lat": 48.0249947,
-    "geo_long": 7.568945,
-    "latitude": 53.2594718,
-    "longitude": -6.6277027
+    "geo_lat": 47.9183833,
+    "geo_long": 7.5724022
   },
   {
     "id": "CanalExtremadura.es",
@@ -4685,23 +4017,19 @@
     "categories": "General;Public",
     "type": "tv",
     "geo_lat": 39.3260685,
-    "geo_long": -4.8379791,
-    "latitude": 48,
-    "longitude": -34
+    "geo_long": -4.8379791
   },
   {
     "id": "CanalMacau.mo",
     "name": "Canal Macau Ch. 92 (720p) [Not 24/7]",
     "url": "https://live3.tdm.com.mo/ch2/ch2.live/playlist.m3u8",
     "logo": "https://i.imgur.com/oFPUZ97.png",
-    "country": "Unknown",
-    "city": "Canal Macau Ch 92 720p Not 247",
+    "country": "China",
+    "city": "Macau",
     "categories": "General",
     "type": "tv",
     "geo_lat": 22.1757605,
-    "geo_long": 113.5514142,
-    "latitude": 50,
-    "longitude": -34
+    "geo_long": 113.5514142
   },
   {
     "id": "CanalMalagaRTV.es",
@@ -4713,9 +4041,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.3260685,
-    "geo_long": -4.8379791,
-    "latitude": 52,
-    "longitude": -34
+    "geo_long": -4.8379791
   },
   {
     "id": "CanalMasTelevision.co",
@@ -4727,9 +4053,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 4.099917,
-    "geo_long": -72.9088133,
-    "latitude": 54,
-    "longitude": -34
+    "geo_long": -72.9088133
   },
   {
     "id": "CanalMultivision.do@SD",
@@ -4741,9 +4065,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 56,
-    "geo_long": -34,
-    "latitude": 56,
-    "longitude": -34
+    "geo_long": -34
   },
   {
     "id": "CanalReusTV.es",
@@ -4755,9 +4077,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.3260685,
-    "geo_long": -4.8379791,
-    "latitude": 41.1465299,
-    "longitude": 1.1123426
+    "geo_long": -4.8379791
   },
   {
     "id": "CanalRicos.br",
@@ -4769,9 +4089,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -10.3333333,
-    "geo_long": -53.2,
-    "latitude": 40,
-    "longitude": -32
+    "geo_long": -53.2
   },
   {
     "id": "CanalSanRoque.es",
@@ -4783,9 +4101,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.3260685,
-    "geo_long": -4.8379791,
-    "latitude": 42,
-    "longitude": -32
+    "geo_long": -4.8379791
   },
   {
     "id": "CanalSierradeCadiz.es",
@@ -4797,9 +4113,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.3260685,
-    "geo_long": -4.8379791,
-    "latitude": 44,
-    "longitude": -32
+    "geo_long": -4.8379791
   },
   {
     "id": "CanalSur2.es",
@@ -4811,9 +4125,7 @@
     "categories": "General;Public",
     "type": "tv",
     "geo_lat": 39.3260685,
-    "geo_long": -4.8379791,
-    "latitude": 46,
-    "longitude": -32
+    "geo_long": -4.8379791
   },
   {
     "id": "CanalTaronjaComarquesCentrals.es",
@@ -4825,9 +4137,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.3260685,
-    "geo_long": -4.8379791,
-    "latitude": 48,
-    "longitude": -32
+    "geo_long": -4.8379791
   },
   {
     "id": "CanalTaronjaOsonaiMoianes.es",
@@ -4839,9 +4149,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.3260685,
-    "geo_long": -4.8379791,
-    "latitude": 50,
-    "longitude": -32
+    "geo_long": -4.8379791
   },
   {
     "id": "CanalTerresdelEbre.es",
@@ -4853,9 +4161,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.3260685,
-    "geo_long": -4.8379791,
-    "latitude": 52,
-    "longitude": -32
+    "geo_long": -4.8379791
   },
   {
     "id": "CanalTRO.co",
@@ -4867,9 +4173,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 4.099917,
-    "geo_long": -72.9088133,
-    "latitude": 54,
-    "longitude": -32
+    "geo_long": -72.9088133
   },
   {
     "id": "CanalTROPlus.co",
@@ -4881,9 +4185,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 4.099917,
-    "geo_long": -72.9088133,
-    "latitude": 56,
-    "longitude": -32
+    "geo_long": -72.9088133
   },
   {
     "id": "CanalZoom.be",
@@ -4895,9 +4197,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 58,
-    "geo_long": -32,
-    "latitude": 58,
-    "longitude": -32
+    "geo_long": -32
   },
   {
     "id": "Canale2Altamura.it",
@@ -4909,9 +4209,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 42.6384261,
-    "geo_long": 12.674297,
-    "latitude": 40,
-    "longitude": -30
+    "geo_long": 12.674297
   },
   {
     "id": "Canale7.it",
@@ -4923,9 +4221,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 42.6384261,
-    "geo_long": 12.674297,
-    "latitude": 45.0790799,
-    "longitude": 7.6830078
+    "geo_long": 12.674297
   },
   {
     "id": "CanangaTV.do",
@@ -4937,9 +4233,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 0.9015369,
-    "geo_long": -79.7072298,
-    "latitude": 0.9015369,
-    "longitude": -79.7072298
+    "geo_long": -79.7072298
   },
   {
     "id": "CanelaTV.do",
@@ -4951,9 +4245,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -29.3636094,
-    "geo_long": -50.8096844,
-    "latitude": -29.3636094,
-    "longitude": -50.8096844
+    "geo_long": -50.8096844
   },
   {
     "id": "CannesLerinsTV.fr",
@@ -4965,9 +4257,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 46.603354,
-    "geo_long": 1.8883335,
-    "latitude": 48,
-    "longitude": -30
+    "geo_long": 1.8883335
   },
   {
     "id": "CaoBangTV.vn",
@@ -4979,9 +4269,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 15.9266657,
-    "geo_long": 107.9650855,
-    "latitude": 34.9947164,
-    "longitude": 135.7661527
+    "geo_long": 107.9650855
   },
   {
     "id": "CapeTownTV.za",
@@ -4993,9 +4281,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -28.8166236,
-    "geo_long": 24.991639,
-    "latitude": -33.9288301,
-    "longitude": 18.4172197
+    "geo_long": 24.991639
   },
   {
     "id": "CapitalTVHD.np",
@@ -5007,9 +4293,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 28.3780464,
-    "geo_long": 83.9999901,
-    "latitude": 48.455818,
-    "longitude": -123.4733796
+    "geo_long": 83.9999901
   },
   {
     "id": "CaprichoTV.ec",
@@ -5021,9 +4305,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -1.3397668,
-    "geo_long": -79.3666965,
-    "latitude": -10.7834852,
-    "longitude": -42.7496427
+    "geo_long": -79.3666965
   },
   {
     "id": "CAPSChannel6.us",
@@ -5035,9 +4317,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.7837304,
-    "geo_long": -100.445882,
-    "latitude": 58,
-    "longitude": -30
+    "geo_long": -100.445882
   },
   {
     "id": "CAPSChannel15.us",
@@ -5049,9 +4329,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.7837304,
-    "geo_long": -100.445882,
-    "latitude": 40,
-    "longitude": -28
+    "geo_long": -100.445882
   },
   {
     "id": "CAtv.pr",
@@ -5063,9 +4341,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 42,
-    "geo_long": -28,
-    "latitude": 42,
-    "longitude": -28
+    "geo_long": -28
   },
   {
     "id": "CaribbeanHot7TV.lc",
@@ -5077,9 +4353,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 13.8250489,
-    "geo_long": -60.975036,
-    "latitude": 44,
-    "longitude": -28
+    "geo_long": -60.975036
   },
   {
     "id": "CaritasTV.py",
@@ -5091,9 +4365,7 @@
     "categories": "General;Religious",
     "type": "tv",
     "geo_lat": -23.3165935,
-    "geo_long": -58.1693445,
-    "latitude": 46,
-    "longitude": -28
+    "geo_long": -58.1693445
   },
   {
     "id": "CityTVCarlsbad.us",
@@ -5105,9 +4377,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 39.7837304,
-    "geo_long": -100.445882,
-    "latitude": 33.6585898,
-    "longitude": -112.4344302
+    "geo_long": -100.445882
   },
   {
     "id": "CascaraTV.do@SD",
@@ -5119,9 +4389,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 47.5035161,
-    "geo_long": -122.6920244,
-    "latitude": 47.5035161,
-    "longitude": -122.6920244
+    "geo_long": -122.6920244
   },
   {
     "id": "CatatumboTV.ve",
@@ -5133,9 +4401,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 8.0018709,
-    "geo_long": -66.1109318,
-    "latitude": 4.1385318,
-    "longitude": -73.6230275
+    "geo_long": -66.1109318
   },
   {
     "id": "Catve2.br",
@@ -5147,23 +4413,19 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -10.3333333,
-    "geo_long": -53.2,
-    "latitude": 54,
-    "longitude": -28
+    "geo_long": -53.2
   },
   {
     "id": "CatveFM.br",
     "name": "Catve FM (720p) [Not 24/7]",
     "url": "https://5b33b873179a2.streamlock.net:1443/radiocamera/livestream/playlist.m3u8",
     "logo": "https://i.imgur.com/w89yw36.png",
-    "country": "Unknown",
-    "city": "Catve FM 720p Not 247",
+    "country": "Brazil",
+    "city": "Cascavel",
     "categories": "General",
     "type": "tv",
     "geo_lat": -24.9554996,
-    "geo_long": -53.4560544,
-    "latitude": 56,
-    "longitude": -28
+    "geo_long": -53.4560544
   },
   {
     "id": "CatveMasterTV.br",
@@ -5175,9 +4437,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": -10.3333333,
-    "geo_long": -53.2,
-    "latitude": 58,
-    "longitude": -28
+    "geo_long": -53.2
   },
   {
     "id": "CayTV.tr@SD",
@@ -5189,23 +4449,19 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 4.82068,
-    "geo_long": -52.3630528,
-    "latitude": 4.82068,
-    "longitude": -52.3630528
+    "geo_long": -52.3630528
   },
   {
     "id": "CBC.eg",
     "name": "CBC (1080p)",
     "url": "https://bcovlive-a.akamaihd.net/0c223ac0a9d34b30b100cb92ee83b70a/us-west-2/6057955906001/playlist.m3u8",
     "logo": "https://i.imgur.com/8apNaLP.png",
-    "country": "Unknown",
-    "city": "CBC 1080p",
+    "country": "Egypt",
+    "city": "Cairo",
     "categories": "General",
     "type": "tv",
     "geo_lat": 30.0443879,
-    "geo_long": 31.2357257,
-    "latitude": 42,
-    "longitude": -26
+    "geo_long": 31.2357257
   },
   {
     "id": "CBRTDT.ca",
@@ -5217,9 +4473,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 61.0666922,
-    "geo_long": -107.991707,
-    "latitude": 44,
-    "longitude": -26
+    "geo_long": -107.991707
   },
   {
     "id": "CBXTDT.ca",
@@ -5231,9 +4485,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 61.0666922,
-    "geo_long": -107.991707,
-    "latitude": 46,
-    "longitude": -26
+    "geo_long": -107.991707
   },
   {
     "id": "CBWTDT.ca",
@@ -5245,9 +4497,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 61.0666922,
-    "geo_long": -107.991707,
-    "latitude": 48,
-    "longitude": -26
+    "geo_long": -107.991707
   },
   {
     "id": "CBMTDT.ca",
@@ -5259,9 +4509,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 61.0666922,
-    "geo_long": -107.991707,
-    "latitude": 50,
-    "longitude": -26
+    "geo_long": -107.991707
   },
   {
     "id": "CBATDT.ca",
@@ -5273,9 +4521,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 61.0666922,
-    "geo_long": -107.991707,
-    "latitude": 52,
-    "longitude": -26
+    "geo_long": -107.991707
   },
   {
     "id": "CBNTDT.ca",
@@ -5287,9 +4533,7 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 61.0666922,
-    "geo_long": -107.991707,
-    "latitude": 47.5707863,
-    "longitude": -52.7369433
+    "geo_long": -107.991707
   },
   {
     "id": "CFYKDT.ca",
@@ -5301,8 +4545,6 @@
     "categories": "General",
     "type": "tv",
     "geo_lat": 61.0666922,
-    "geo_long": -107.991707,
-    "latitude": 56,
-    "longitude": -26
+    "geo_long": -107.991707
   }
 ]


### PR DESCRIPTION
This commit fixes the incorrect locations of many TV and radio stations, including a batch of stations that were appearing in the middle of the Atlantic Ocean.

The `geocodeStations.js` script has been improved to:
- Identify stations with placeholder or incorrect coordinates, including those in the Atlantic.
- Infer country from the station ID when the country is "Unknown".
- Geocode the station location using the OpenStreetMap Nominatim API.
- Update the data files in-place.